### PR TITLE
✨🔥 33 - Add participant, clinician route dirs. Delete sample page

### DIFF
--- a/apps/ui/src/app/[lang]/clinician/registration/index.tsx
+++ b/apps/ui/src/app/[lang]/clinician/registration/index.tsx
@@ -17,25 +17,18 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { User } from 'common';
+import Link from 'next/link';
 
-import { ValidLanguage, getTranslation } from '@/i18n';
+import { getTranslation, ValidLanguage } from '@/i18n';
 
-const user: User = {
-  id: '1',
-  name: 'Homer Simpson',
-  email: 'homersimpson@example.com',
-};
-
-const HomeComponent = async ({ lang }: { lang: ValidLanguage }) => {
+const ClinicianRegistration = async ({ lang }: { lang: ValidLanguage }) => {
   const translate = await getTranslation(lang);
   return (
     <div>
-      <h1>{translate('title')}</h1>
-      <p>{translate('sample-text')}</p>
-      <h2>{translate('greeting', { name: user.name })}</h2>
+      <h2>{translate('clinician-registration')}</h2>
+      <Link href={`/${lang}`}>{translate('home')}</Link>
     </div>
   );
 };
 
-export default HomeComponent;
+export default ClinicianRegistration;

--- a/apps/ui/src/app/[lang]/clinician/registration/page.tsx
+++ b/apps/ui/src/app/[lang]/clinician/registration/page.tsx
@@ -17,18 +17,13 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import Link from 'next/link';
+import { ValidLanguage } from '@/i18n';
+import ClinicianRegistration from '.';
 
-import { getTranslation, ValidLanguage } from '@/i18n';
-
-const Second = async ({ lang }: { lang: ValidLanguage }) => {
-  const translate = await getTranslation(lang, 'second-page');
-  return (
-    <div>
-      <h1>{translate('title')}</h1>
-      <Link href={`/${lang}`}>{translate('back-to-home')}</Link>
-    </div>
-  );
-};
-
-export default Second;
+export default async function Page({
+  params: { lang },
+}: {
+  params: { lang: ValidLanguage };
+}) {
+  return <ClinicianRegistration lang={lang} />;
+}

--- a/apps/ui/src/app/[lang]/participant/consent-forms/index.tsx
+++ b/apps/ui/src/app/[lang]/participant/consent-forms/index.tsx
@@ -17,25 +17,18 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { User } from 'common';
+import Link from 'next/link';
 
-import { ValidLanguage, getTranslation } from '@/i18n';
+import { getTranslation, ValidLanguage } from '@/i18n';
 
-const user: User = {
-  id: '1',
-  name: 'Homer Simpson',
-  email: 'homersimpson@example.com',
-};
-
-const HomeComponent = async ({ lang }: { lang: ValidLanguage }) => {
+const ConsentForm = async ({ lang }: { lang: ValidLanguage }) => {
   const translate = await getTranslation(lang);
   return (
     <div>
-      <h1>{translate('title')}</h1>
-      <p>{translate('sample-text')}</p>
-      <h2>{translate('greeting', { name: user.name })}</h2>
+      <h2>{translate('consent-form')}</h2>
+      <Link href={`/${lang}`}>{translate('home')}</Link>
     </div>
   );
 };
 
-export default HomeComponent;
+export default ConsentForm;

--- a/apps/ui/src/app/[lang]/participant/consent-forms/page.tsx
+++ b/apps/ui/src/app/[lang]/participant/consent-forms/page.tsx
@@ -17,13 +17,13 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import Second from './Second';
 import { ValidLanguage } from '@/i18n';
+import ConsentForm from '.';
 
 export default async function Page({
   params: { lang },
 }: {
   params: { lang: ValidLanguage };
 }) {
-  return <Second lang={lang} />;
+  return <ConsentForm lang={lang} />;
 }

--- a/apps/ui/src/app/[lang]/participant/dashboard/index.tsx
+++ b/apps/ui/src/app/[lang]/participant/dashboard/index.tsx
@@ -17,25 +17,18 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { User } from 'common';
+import Link from 'next/link';
 
-import { ValidLanguage, getTranslation } from '@/i18n';
+import { getTranslation, ValidLanguage } from '@/i18n';
 
-const user: User = {
-  id: '1',
-  name: 'Homer Simpson',
-  email: 'homersimpson@example.com',
-};
-
-const HomeComponent = async ({ lang }: { lang: ValidLanguage }) => {
+const Dashboard = async ({ lang }: { lang: ValidLanguage }) => {
   const translate = await getTranslation(lang);
   return (
     <div>
-      <h1>{translate('title')}</h1>
-      <p>{translate('sample-text')}</p>
-      <h2>{translate('greeting', { name: user.name })}</h2>
+      <h1>{translate('dashboard')}</h1>
+      <Link href={`/${lang}`}>{translate('home')}</Link>
     </div>
   );
 };
 
-export default HomeComponent;
+export default Dashboard;

--- a/apps/ui/src/app/[lang]/participant/dashboard/page.tsx
+++ b/apps/ui/src/app/[lang]/participant/dashboard/page.tsx
@@ -17,25 +17,13 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { User } from 'common';
+import { ValidLanguage } from '@/i18n';
+import Dashboard from '.';
 
-import { ValidLanguage, getTranslation } from '@/i18n';
-
-const user: User = {
-  id: '1',
-  name: 'Homer Simpson',
-  email: 'homersimpson@example.com',
-};
-
-const HomeComponent = async ({ lang }: { lang: ValidLanguage }) => {
-  const translate = await getTranslation(lang);
-  return (
-    <div>
-      <h1>{translate('title')}</h1>
-      <p>{translate('sample-text')}</p>
-      <h2>{translate('greeting', { name: user.name })}</h2>
-    </div>
-  );
-};
-
-export default HomeComponent;
+export default async function Page({
+  params: { lang },
+}: {
+  params: { lang: ValidLanguage };
+}) {
+  return <Dashboard lang={lang} />;
+}

--- a/apps/ui/src/app/[lang]/participant/registration/index.tsx
+++ b/apps/ui/src/app/[lang]/participant/registration/index.tsx
@@ -17,25 +17,18 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { User } from 'common';
+import Link from 'next/link';
 
-import { ValidLanguage, getTranslation } from '@/i18n';
+import { getTranslation, ValidLanguage } from '@/i18n';
 
-const user: User = {
-  id: '1',
-  name: 'Homer Simpson',
-  email: 'homersimpson@example.com',
-};
-
-const HomeComponent = async ({ lang }: { lang: ValidLanguage }) => {
+const Registration = async ({ lang }: { lang: ValidLanguage }) => {
   const translate = await getTranslation(lang);
   return (
     <div>
-      <h1>{translate('title')}</h1>
-      <p>{translate('sample-text')}</p>
-      <h2>{translate('greeting', { name: user.name })}</h2>
+      <h2>{translate('registration')}</h2>
+      <Link href={`/${lang}`}>{translate('home')}</Link>
     </div>
   );
 };
 
-export default HomeComponent;
+export default Registration;

--- a/apps/ui/src/app/[lang]/participant/registration/page.tsx
+++ b/apps/ui/src/app/[lang]/participant/registration/page.tsx
@@ -17,25 +17,13 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { User } from 'common';
+import { ValidLanguage } from '@/i18n';
+import Registration from '.';
 
-import { ValidLanguage, getTranslation } from '@/i18n';
-
-const user: User = {
-  id: '1',
-  name: 'Homer Simpson',
-  email: 'homersimpson@example.com',
-};
-
-const HomeComponent = async ({ lang }: { lang: ValidLanguage }) => {
-  const translate = await getTranslation(lang);
-  return (
-    <div>
-      <h1>{translate('title')}</h1>
-      <p>{translate('sample-text')}</p>
-      <h2>{translate('greeting', { name: user.name })}</h2>
-    </div>
-  );
-};
-
-export default HomeComponent;
+export default async function Page({
+  params: { lang },
+}: {
+  params: { lang: ValidLanguage };
+}) {
+  return <Registration lang={lang} />;
+}

--- a/apps/ui/src/i18n/locales/en/common.json
+++ b/apps/ui/src/i18n/locales/en/common.json
@@ -1,6 +1,10 @@
 {
-    "title": "OHCRN Patient Enrolment Portal",
-    "greeting": "Hi there!",
-    "to-second-page": "To second page",
-    "sample-text": "Sample text for the landing page."
+  "title": "OHCRN Patient Enrolment Portal",
+  "greeting": "Hi there!",
+  "sample-text": "Sample text for the landing page.",
+  "home": "Homepage",
+  "registration": "Registration",
+  "dashboard": "Dashboard",
+  "consent-form": "Consent Forms",
+  "clinician-registration": "Clinician Registration"
 }

--- a/apps/ui/src/i18n/locales/en/second-page.json
+++ b/apps/ui/src/i18n/locales/en/second-page.json
@@ -1,4 +1,0 @@
-{
-    "title": "Hi from second page!",
-    "back-to-home": "Back to home"
-  }

--- a/apps/ui/src/i18n/locales/fr/common.json
+++ b/apps/ui/src/i18n/locales/fr/common.json
@@ -1,6 +1,10 @@
 {
-    "title": "Portail d'inscription des patients de l'OHRCN",
-    "greeting": "Bonjour, {{ name }}!",
-    "to-second-page": "Au deuxième page",
-    "sample-text": "Exemple de texte pour la page de destination."
+  "title": "Portail d'inscription des patients de l'OHRCN",
+  "greeting": "Bonjour, {{ name }}!",
+  "sample-text": "Exemple de texte pour la page de destination.",
+  "home": "Page d'accueil",
+  "registration": "Inscription",
+  "dashboard": "Tableau de bord",
+  "consent-form": "Formulaires de consentement",
+  "clinician-registration": "Inscription du clinicien"
 }

--- a/apps/ui/src/i18n/locales/fr/second-page.json
+++ b/apps/ui/src/i18n/locales/fr/second-page.json
@@ -1,4 +1,0 @@
-{
-    "title": "Bonjour du deuxième page!",
-    "back-to-home": "Retour à la page d'accueil"
-  }

--- a/apps/ui/src/i18n/types/dictionaries.ts
+++ b/apps/ui/src/i18n/types/dictionaries.ts
@@ -19,12 +19,7 @@
 
 import { ValidLanguage } from './languages';
 
-export const namespaces = [
-  'common',
-  'header',
-  'second-page',
-  'footer',
-] as const;
+export const namespaces = ['common', 'header', 'footer'] as const;
 export type ValidNamespace = (typeof namespaces)[number];
 
 export type Translation = (


### PR DESCRIPTION
Adds routes for:
- `/participant/registration`
- `/participant/dashboard`
- `/participant/consent-forms`
- `/clinician/registration`

Removes sample `/second-page` route and dictionary namespace
Pages are empty components for now; added page title translations just to id pages.

Note: will create sensible namespaces for dictionaries as components are created