### PR TITLE
♻️ Use package.json's registry version in footer (#59)

### DIFF
--- a/apps/consent-ui/src/components/Footer/Versions.tsx
+++ b/apps/consent-ui/src/components/Footer/Versions.tsx
@@ -21,6 +21,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import clsx from 'clsx';
 
+import packageJson from '@/../package.json';
 import GithubLogo from '@/public/github.svg';
 import OvertureLogo from '@/public/overture.svg';
 import { ValidLanguage, getTranslation } from '@/i18n';
@@ -44,10 +45,7 @@ const Versions = async ({ lang }: { lang: ValidLanguage }) => {
 			</div>
 			<div className={styles.copyright}>
 				<span>{translate('copyright')} </span>
-				<span>
-					{/* TODO: fix hardcoded version */}
-					{translate('ohcrn-registry', { registryVersion: '0.1.0' })} -{' '}
-				</span>
+				<span>{translate('ohcrn-registry', { registryVersion: packageJson.version })} - </span>
 				{/* TODO: fix hardcoded version */}
 				<span>{translate('api', { apiVersion: '0.1.0' })}</span>
 			</div>


### PR DESCRIPTION
Updates the Footer component to use the version from consent-ui's package.json as the registry version.