### PR TITLE
🗃️ Add Participant Response Prisma schema

### DIFF
--- a/apps/consent-das/src/prismaClient.ts
+++ b/apps/consent-das/src/prismaClient.ts
@@ -17,11 +17,17 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { PrismaClient, Participant, ConsentQuestion, ConsentCategory } from './generated/client';
+import {
+	PrismaClient,
+	Participant,
+	ConsentQuestion,
+	ConsentCategory,
+	ParticipantResponse,
+} from './generated/client';
 import logger from './logger';
 
 logger.info('Initializing prismaClient.ts');
 const prisma = new PrismaClient();
 
-export { Participant, ConsentQuestion, ConsentCategory };
+export { Participant, ConsentQuestion, ConsentCategory, ParticipantResponse };
 export default prisma;

--- a/apps/consent-das/src/service/create.ts
+++ b/apps/consent-das/src/service/create.ts
@@ -1,4 +1,9 @@
-import prisma, { Participant, ConsentQuestion, ConsentCategory } from '../prismaClient';
+import prisma, {
+	Participant,
+	ConsentQuestion,
+	ConsentCategory,
+	ParticipantResponse,
+} from '../prismaClient';
 
 export const createParticipant = async ({
 	participantId,
@@ -35,6 +40,29 @@ export const createConsentQuestion = async ({
 			isActive,
 			createdAt,
 			category,
+		},
+	});
+	return result;
+};
+
+export const createParticipantResponse = async ({
+	participantId,
+	consentQuestionId,
+	response,
+	submittedAt,
+}: {
+	participantId: string;
+	consentQuestionId: string;
+	response: boolean;
+	submittedAt: Date;
+}): Promise<ParticipantResponse> => {
+	// TODO: add error handling
+	const result = await prisma.participantResponse.create({
+		data: {
+			participantId,
+			consentQuestionId,
+			response,
+			submittedAt,
 		},
 	});
 	return result;

--- a/apps/consent-das/src/service/create.ts
+++ b/apps/consent-das/src/service/create.ts
@@ -49,12 +49,10 @@ export const createParticipantResponse = async ({
 	participantId,
 	consentQuestionId,
 	response,
-	submittedAt,
 }: {
 	participantId: string;
 	consentQuestionId: string;
 	response: boolean;
-	submittedAt: Date;
 }): Promise<ParticipantResponse> => {
 	// TODO: add error handling
 	const result = await prisma.participantResponse.create({
@@ -62,7 +60,6 @@ export const createParticipantResponse = async ({
 			participantId,
 			consentQuestionId,
 			response,
-			submittedAt,
 		},
 	});
 	return result;

--- a/apps/consent-das/src/service/search.ts
+++ b/apps/consent-das/src/service/search.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '../generated/client';
 import prisma, {
 	Participant,
 	ConsentQuestion,
@@ -67,7 +68,7 @@ export const getParticipantResponse = async (
 export const getParticipantResponses = async (
 	participantId: string,
 	consentQuestionId: string,
-	ascending?: boolean,
+	sortOrder: Prisma.SortOrder = Prisma.SortOrder.desc,
 ): Promise<ParticipantResponse[]> => {
 	// TODO: add error handling
 	const result = await prisma.participantResponse.findMany({
@@ -77,7 +78,7 @@ export const getParticipantResponses = async (
 		},
 		orderBy: {
 			// defaults to sort by most recently submitted responses first
-			submittedAt: ascending ? 'asc' : 'desc',
+			submittedAt: sortOrder,
 		},
 	});
 	return result;

--- a/apps/consent-das/src/service/search.ts
+++ b/apps/consent-das/src/service/search.ts
@@ -33,25 +33,38 @@ export const getConsentQuestions = async (): Promise<ConsentQuestion[]> => {
 };
 
 export const getParticipantResponse = async (
-	id: string,
 	participantId: string,
 	consentQuestionId: string,
 ): Promise<ParticipantResponse> => {
 	// TODO: add error handling
-	const result = await prisma.participantResponse.findUniqueOrThrow({
+	const result = await prisma.participantResponse.findFirstOrThrow({
 		where: {
-			id_participantId_consentQuestionId: {
-				id,
-				participantId,
-				consentQuestionId,
-			},
+			participantId,
+			consentQuestionId,
+		},
+		orderBy: {
+			// gets the most recently submitted response
+			submittedAt: 'desc',
 		},
 	});
 	return result;
 };
 
-export const getParticipantResponses = async (): Promise<ParticipantResponse[]> => {
+export const getParticipantResponses = async (
+	participantId: string,
+	consentQuestionId: string,
+	ascending?: boolean,
+): Promise<ParticipantResponse[]> => {
 	// TODO: add error handling
-	const result = await prisma.participantResponse.findMany();
+	const result = await prisma.participantResponse.findMany({
+		where: {
+			participantId,
+			consentQuestionId,
+		},
+		orderBy: {
+			// defaults to sort by most recently submitted responses first
+			submittedAt: ascending ? 'asc' : 'desc',
+		},
+	});
 	return result;
 };

--- a/apps/consent-das/src/service/search.ts
+++ b/apps/consent-das/src/service/search.ts
@@ -1,4 +1,4 @@
-import prisma, { Participant, ConsentQuestion } from '../prismaClient';
+import prisma, { Participant, ConsentQuestion, ParticipantResponse } from '../prismaClient';
 
 export const getParticipant = async (participantId: string): Promise<Participant> => {
 	// TODO: add error handling
@@ -29,5 +29,29 @@ export const getConsentQuestion = async (id: string): Promise<ConsentQuestion> =
 export const getConsentQuestions = async (): Promise<ConsentQuestion[]> => {
 	// TODO: add error handling
 	const result = await prisma.consentQuestion.findMany();
+	return result;
+};
+
+export const getParticipantResponse = async (
+	id: string,
+	participantId: string,
+	consentQuestionId: string,
+): Promise<ParticipantResponse> => {
+	// TODO: add error handling
+	const result = await prisma.participantResponse.findUniqueOrThrow({
+		where: {
+			id_participantId_consentQuestionId: {
+				id,
+				participantId,
+				consentQuestionId,
+			},
+		},
+	});
+	return result;
+};
+
+export const getParticipantResponses = async (): Promise<ParticipantResponse[]> => {
+	// TODO: add error handling
+	const result = await prisma.participantResponse.findMany();
 	return result;
 };


### PR DESCRIPTION
- Added the Participant Response create/read methods
- Seed data not necessary since responses will be created with users + questions via an api call later on

Note that this branch was created from #91 due to the existing schema in that branch, so the changes are compounded from that.