### PR TITLE
fix LocalizedLink href structure

### DIFF
--- a/apps/consent-ui/src/components/Link/LocalizedLink.tsx
+++ b/apps/consent-ui/src/components/Link/LocalizedLink.tsx
@@ -53,9 +53,9 @@ const LocalizedLink = ({
 	if (params) {
 		href = addParamsToUrl(href, params);
 	}
-
+	const fullPath = `/${urlJoin(locale, href)}`;
 	return (
-		<Link href={urlJoin(locale, href)} className={className} {...rest}>
+		<Link href={fullPath} className={className} {...rest}>
 			{children}
 		</Link>
 	);

--- a/apps/consent-ui/src/components/Link/utils.ts
+++ b/apps/consent-ui/src/components/Link/utils.ts
@@ -36,7 +36,7 @@ export const getLinkNameByPath = (path: string, lang: ValidLanguage): RouteName 
 		const validRoute = RouteNameEnum.parse(result);
 		return validRoute;
 	} catch (e) {
-		console.error(`Invalid route name: ${result}`);
+		console.error(`Invalid route name: ${result} from path: "${path}"`);
 		return 'home';
 	}
 };


### PR DESCRIPTION
adds a leading `/` to the `LocalizedLink` component href to fix a routing issue that (maybe?) appeared after the env var stuff got merged. TBH not sure how it was working originally!
- also fixes the prefetch link that can be seen with the browser inspector