### PR TITLE
🚑️ Fix renaming ButtonSize type bug

### DIFF
--- a/apps/consent-ui/src/components/Button/LinkButton.tsx
+++ b/apps/consent-ui/src/components/Button/LinkButton.tsx
@@ -10,7 +10,7 @@ const LinkButton = ({
 	href,
 	variant = 'primary',
 	color = 'default',
-	size = 'default',
+	size = 'base',
 	layout = 'default',
 	children,
 	className = '',


### PR DESCRIPTION
- a dumb error that I didn't catch for some reason after renaming the types of ButtonSize (not sure why it was able to build without this 🤔)