### PR TITLE
🚨 Fix whitespace in Swagger JSDocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ To keep commit messages consistent, we use [gitmoji](https://gitmoji.dev). To ea
 
 ## Local Development
 
-To run the setup locally, ensure you have provided the **required** environment variables, as described in [Environment Variables](#environment-variables). Each package has an `.env.schema` file for reference.
+To run the setup locally, ensure you have provided the **required** environment variables, as described in [Environment Variables](#environment-variables). Each package has an `.env.schema` file for reference, which you can create a copy of and rename to `.env` unless otherwise specified.
 
 - In the [`./` project root folder](./), create an `.env` file copy of the root [`.env.schema`](./.env.schema) file
 - In the [`/apps/consent-api/` folder](./apps/consent-api/), create an `.env` file
 - In the [`/apps/consent-das/` folder](./apps/consent-das/), create an `.env` file
-- In the [`/apps/consent-ui/` folder](./apps/consent-ui/), create and `.env.local` file
+- In the [`/apps/consent-ui/` folder](./apps/consent-ui/), create an `.env.local` file
 - In the [`/apps/data-mapper/` folder](./apps/data-mapper/), create an `.env` file
 - In the [`/apps/keys-das/` folder](./apps/keys-das/), create an `.env` file
 - In the [`/apps/phi-das/` folder](./apps/phi-das/), create an `.env` file
@@ -73,6 +73,7 @@ To run the setup locally, ensure you have provided the **required** environment 
 | `.`           | `POSTGRES_USER`   | Docker Postgres database user     | `string` | Required | `postgres`                                               |
 | `.`           | `POSTGRES_USER`   | Docker Postgres database password | `string` | Required | `postgres`                                               |
 | `consent-api` | `PORT`            | Port number for the Consent API   | `number` | Optional | `8080`                                                   |
+| `consent-api` | `NODE_ENV`        | Node environment name             | `string` | Required | `development`                                            |
 | `consent-das` | `DATABASE_URL`    | URL for the Consent DB            | `string` | Required | `postgres://postgres:postgres@localhost:5432/consent_db` |
 | `consent-das` | `PORT`            | Port number for the Consent DAS   | `number` | Optional | `8085`                                                   |
 | `consent-ui`  | `CONSENT_API_URL` | URL for the Consent API           | `string` | Optional | `http://localhost:8080`                                  |

--- a/apps/consent-api/.env.schema
+++ b/apps/consent-api/.env.schema
@@ -1,1 +1,2 @@
+NODE_ENV=development
 PORT=8080

--- a/apps/consent-api/src/routers/consentQuestions.ts
+++ b/apps/consent-api/src/routers/consentQuestions.ts
@@ -49,8 +49,13 @@ const router = Router();
  *         in: query
  *         description: Consent question category
  *         schema:
- *            type: Enum
- *            enum: [INFORMED_CONSENT, CONSENT_RELEASE_DATA, CONSENT_RESEARCH_PARTICIPATION, CONSENT_RECONTACT, CONSENT_REVIEW_SIGN]
+ *            type: string
+ *            enum:
+ *              - INFORMED_CONSENT
+ *              - CONSENT_RELEASE_DATA
+ *              - CONSENT_RESEARCH_PARTICIPATION
+ *              - CONSENT_RECONTACT
+ *              - CONSENT_REVIEW_SIGN
  *     responses:
  *       200:
  *         description: The list of questions was successfully retrieved.

--- a/apps/consent-das/src/routers/consentQuestions.ts
+++ b/apps/consent-das/src/routers/consentQuestions.ts
@@ -147,7 +147,12 @@ router.get('/:consentQuestionId', async (req, res) => {
  *                 type: boolean
  *               category:
  *                 type: string
- *                 enum: [INFORMED_CONSENT, CONSENT_RELEASE_DATA, CONSENT_RESEARCH_PARTICIPATION, CONSENT_RECONTACT, CONSENT_REVIEW_SIGN]
+ *                 enum:
+ *                   - INFORMED_CONSENT
+ *                   - CONSENT_RELEASE_DATA
+ *                   - CONSENT_RESEARCH_PARTICIPATION
+ *                   - CONSENT_RECONTACT
+ *                   - CONSENT_REVIEW_SIGN
  *     responses:
  *       201:
  *         description: The question was successfully created.

--- a/apps/consent-das/src/routers/consentQuestions.ts
+++ b/apps/consent-das/src/routers/consentQuestions.ts
@@ -130,7 +130,7 @@ router.get('/:consentQuestionId', async (req, res) => {
  *   post:
  *     tags:
  *       - Consent Questions
- *     summary: Create Consent Question
+ *     name: Create Consent Question
  *     description: Create one consent question
  *     security:
  *       - bearerAuth: []

--- a/apps/consent-das/src/routers/consentQuestions.ts
+++ b/apps/consent-das/src/routers/consentQuestions.ts
@@ -50,8 +50,13 @@ const router = Router();
  *         in: query
  *         description: Consent question category
  *         schema:
- *            type: Enum
- *            enum: [INFORMED_CONSENT, CONSENT_RELEASE_DATA, CONSENT_RESEARCH_PARTICIPATION, CONSENT_RECONTACT, CONSENT_REVIEW_SIGN]
+ *           type: string
+ *           enum:
+ *             - INFORMED_CONSENT
+ *             - CONSENT_RELEASE_DATA
+ *             - CONSENT_RESEARCH_PARTICIPATION
+ *             - CONSENT_RECONTACT
+ *             - CONSENT_REVIEW_SIGN
  *     responses:
  *       200:
  *         description: The list of questions was successfully retrieved.
@@ -94,12 +99,12 @@ router.get('/', async (req, res) => {
  *     security:
  *       - bearerAuth: []
  *     parameters:
- *      - name: consentQuestionId
- *        in: path
- *        description: Consent Question ID
- *        required: true
- *        schema:
- *          type: string
+ *       - name: consentQuestionId
+ *         in: path
+ *         description: Consent Question ID
+ *         required: true
+ *         schema:
+ *           type: string
  *     responses:
  *       200:
  *         description: The question was successfully retrieved.
@@ -121,11 +126,11 @@ router.get('/:consentQuestionId', async (req, res) => {
 
 /**
  * @openapi
- * /consent-questions/:
+ * /consent-questions:
  *   post:
  *     tags:
  *       - Consent Questions
- *     name: Create Consent Question
+ *     summary: Create Consent Question
  *     description: Create one consent question
  *     security:
  *       - bearerAuth: []
@@ -141,8 +146,8 @@ router.get('/:consentQuestionId', async (req, res) => {
  *               isActive:
  *                 type: boolean
  *               category:
- *                 type: Enum
- * 				   enum: [INFORMED_CONSENT, CONSENT_RELEASE_DATA, CONSENT_RESEARCH_PARTICIPATION, CONSENT_RECONTACT, CONSENT_REVIEW_SIGN]
+ *                 type: string
+ *                 enum: [INFORMED_CONSENT, CONSENT_RELEASE_DATA, CONSENT_RESEARCH_PARTICIPATION, CONSENT_RECONTACT, CONSENT_REVIEW_SIGN]
  *     responses:
  *       201:
  *         description: The question was successfully created.
@@ -168,17 +173,17 @@ router.post('/', async (req, res) => {
  *   patch:
  *     tags:
  *       - Consent Questions
- *     name: Create Consent Question
+ *     name: Update Consent Question
  *     description: Update consent question's isActive field by ID
  *     security:
  *       - bearerAuth: []
  *     parameters:
- *      - name: consentQuestionId
- *        in: path
- *        description: Consent Question ID
- *        required: true
- *        schema:
- *          type: string
+ *       - name: consentQuestionId
+ *         in: path
+ *         description: Consent Question ID
+ *         required: true
+ *         schema:
+ *           type: string
  *     requestBody:
  *       required: true
  *       content:

--- a/apps/consent-das/src/routers/participants.ts
+++ b/apps/consent-das/src/routers/participants.ts
@@ -73,12 +73,12 @@ router.get('/', async (req, res) => {
  *     security:
  *       - bearerAuth: []
  *     parameters:
- *      - name: participantId
- *        in: path
- *        description: Participant ID
- *        required: true
- *        schema:
- *          type: string
+ *       - name: participantId
+ *         in: path
+ *         description: Participant ID
+ *         required: true
+ *         schema:
+ *           type: string
  *     responses:
  *       200:
  *         description: The participant was successfully retrieved.
@@ -122,11 +122,16 @@ router.get('/:participantId', async (req, res) => {
  *               isGuardian:
  *                 type: boolean
  *               consentGroup:
- *                 type: Enum
- * 				   enum: [ADULT_CONSENT, ADULT_CONSENT_SUBSTITUTE_DECISION_MAKER, GUARDIAN_CONSENT_OF_MINOR, GUARDIAN_CONSENT_OF_MINOR_INCLUDING_ASSENT, YOUNG_ADULT_CONSENT]
+ *                 type: string
+ *                 enum:
+ *                   - ADULT_CONSENT
+ *                   - ADULT_CONSENT_SUBSTITUTE_DECISION_MAKER
+ *                   - GUARDIAN_CONSENT_OF_MINOR
+ *                   - GUARDIAN_CONSENT_OF_MINOR_INCLUDING_ASSENT
+ *                   - YOUNG_ADULT_CONSENT
  *               guardianIdVerified:
- *                 	type: boolean
- * 			   required:
+ *                 type: boolean
+ *             required:
  *               - emailVerified
  *               - isGuardian
  *     responses:


### PR DESCRIPTION
- didn't pull the swagger updates to develop before merging #101 so I wasn't able to see the jsdoc lib errors for the Swagger JSDocs
- couldn't find a programmatic way to fix this other than checking where the linter is complaining and removing tabs/adding spaces, swagger-jsdocs was being annoying when I tried to just return the swagger spec yaml or json
- I guess the current approach to avoiding this error is to check the linter as you add comments (which wasn't possible when I was adding these comments in originally so this should be fine from now on)
- also added NODE_ENV to consent-api's `.env.schema` and updated the README