### PR TITLE
🦺 Add ConsentQuestion Zod schema

### DIFF
--- a/packages/types/src/entities/ConsentQuestion.ts
+++ b/packages/types/src/entities/ConsentQuestion.ts
@@ -1,0 +1,11 @@
+import * as z from 'zod';
+
+import { ConsentCategory } from './ConsentCategory.js';
+
+export const ConsentQuestion = z.object({
+	id: z.string().trim(),
+	isActive: z.boolean(),
+	category: ConsentCategory,
+});
+
+export type ConsentQuestion = z.infer<typeof ConsentQuestion>;


### PR DESCRIPTION
- didn't include `createdAt` field since this is not included in user input, and is created by default by the database
- checking for whitespace in the `id` field (which is manually created for consent questions) with `trim()`