### PR TITLE
🦺 Map out /register endpoint in consent-api

### DIFF
--- a/apps/consent-api/src/index.ts
+++ b/apps/consent-api/src/index.ts
@@ -24,6 +24,7 @@ import bodyParser from 'body-parser';
 import { AppConfig } from './config.js';
 import SwaggerRouter from './routers/swagger.js';
 import StatusRouter from './routers/status.js';
+import RegisterRouter from './routers/register.js';
 import ParticipantRouter from './routers/participants.js';
 import ConsentQuestionRouter from './routers/consentQuestions.js';
 import ParticipantResponseRouter from './routers/participantResponses.js';
@@ -48,6 +49,7 @@ const App = (config: AppConfig) => {
 	// set up routers
 	app.use('/api-docs', SwaggerRouter);
 	app.use('/status', StatusRouter);
+	app.use('/register', RegisterRouter);
 	app.use('/participants', ParticipantRouter);
 	app.use('/consent-questions', ConsentQuestionRouter);
 	app.use('/participant-responses', ParticipantResponseRouter);

--- a/apps/consent-api/src/routers/register.ts
+++ b/apps/consent-api/src/routers/register.ts
@@ -46,7 +46,7 @@ const router = Router();
  *       content:
  *         application/json:
  *           schema:
- *             $ref: '#/components/schemas/ParticipantRegistrationRequest'
+ *             $ref: '#/components/schemas/ParticipantRegistration'
  *     responses:
  *       200:
  *         description: OK

--- a/apps/consent-api/src/routers/register.ts
+++ b/apps/consent-api/src/routers/register.ts
@@ -18,61 +18,45 @@
  */
 
 import { Router } from 'express';
-import { serve, setup } from 'swagger-ui-express';
-import swaggerJsdoc from 'swagger-jsdoc';
-import { ParticipantRegistrationRequest } from 'types/entities';
 
-import packageJson from '../../package.json' assert { type: 'json' };
+import logger from '../logger.js';
 
 /**
  * @openapi
- * components:
- *   securitySchemes:
- *     bearerAuth:
- *       type: http
- *       scheme: bearer
- *       bearerFormat: JWT
- *   schemas:
- *     Error:
- *       type: object
- *       properties:
- *         error:
- *           type: string
- *         message:
- *           type: string
- *       required:
- *          - code
- *          - message
+ * tags:
+ *   - name: Register
+ *     description: Participant Self-Registration
  */
 
-const options = swaggerJsdoc({
-	failOnErrors: true,
-	definition: {
-		openapi: '3.1.0',
-		info: {
-			title: 'OHCRN Consent API',
-			version: packageJson.version,
-			description: '',
-			license: {
-				name: 'APGL',
-				url: 'https://www.gnu.org/licenses/agpl-3.0.en.html',
-			},
-			servers: [
-				{
-					url: '/',
-				},
-			],
-		},
-		components: {
-			schemas: {
-				ParticipantRegistrationRequest,
-			},
-		},
-	},
-	apis: ['./src/routers/*'],
-});
-
 const router = Router();
-router.use('/', serve, setup(options));
+
+/**
+ * @openapi
+ * /register:
+ *   post:
+ *     tags:
+ *       - Register
+ *     name: Register Participant
+ *     description: Create participant with Keycloak ID and email
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/ParticipantRegistrationRequest'
+ *     responses:
+ *       200:
+ *         description: OK
+ *       500:
+ *         description: Server error
+ */
+router.post('/', async (req, res) => {
+	logger.info(`POST /register`);
+	// TODO: implement
+	const response = { message: `Participant (un)successfully registered` };
+	res.json(response);
+});
 
 export default router;

--- a/apps/consent-api/src/routers/register.ts
+++ b/apps/consent-api/src/routers/register.ts
@@ -18,6 +18,7 @@
  */
 
 import { Router } from 'express';
+import { ParticipantRegistration } from 'types/entities';
 
 import logger from '../logger.js';
 
@@ -54,9 +55,14 @@ const router = Router();
  */
 router.post('/', async (req, res) => {
 	logger.info(`POST /register`);
-	// TODO: implement
-	const response = { message: `Participant (un)successfully registered` };
-	res.json(response);
+	try {
+		const body = ParticipantRegistration.parse(req.body);
+		// TODO: implement
+		res.status(200).send({ message: `Participant (un)successfully registered`, body });
+	} catch (error) {
+		logger.error(error);
+		res.status(500).send({ message: 'An error occurred' });
+	}
 });
 
 export default router;

--- a/apps/consent-api/src/routers/swagger.ts
+++ b/apps/consent-api/src/routers/swagger.ts
@@ -20,7 +20,7 @@
 import { Router } from 'express';
 import { serve, setup } from 'swagger-ui-express';
 import swaggerJsdoc from 'swagger-jsdoc';
-import { ParticipantRegistrationRequest } from 'types/entities';
+import { ParticipantRegistrationOpenAPISchema as ParticipantRegistration } from 'types/entities';
 
 import packageJson from '../../package.json' assert { type: 'json' };
 
@@ -65,7 +65,7 @@ const options = swaggerJsdoc({
 		},
 		components: {
 			schemas: {
-				ParticipantRegistrationRequest,
+				ParticipantRegistration,
 			},
 		},
 	},

--- a/apps/consent-das/prisma/migrations/20231019145857_add_consent_to_be_contacted_to_participant/migration.sql
+++ b/apps/consent-das/prisma/migrations/20231019145857_add_consent_to_be_contacted_to_participant/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Participant" ADD COLUMN     "consentToBeContacted" BOOLEAN NOT NULL DEFAULT false;

--- a/apps/consent-das/prisma/schema.prisma
+++ b/apps/consent-das/prisma/schema.prisma
@@ -17,12 +17,13 @@ enum ConsentGroup {
 }
 
 model Participant {
-  id                  String                @id @default(cuid())
-  consentGroup        ConsentGroup?
-  emailVerified       Boolean               @default(false)
-  isGuardian          Boolean
-  guardianIdVerified  Boolean?
-  ParticipantResponse ParticipantResponse[]
+  id                   String                @id @default(cuid())
+  consentGroup         ConsentGroup?
+  consentToBeContacted Boolean               @default(false)
+  emailVerified        Boolean               @default(false)
+  isGuardian           Boolean
+  guardianIdVerified   Boolean?
+  ParticipantResponse  ParticipantResponse[]
 }
 
 enum ConsentCategory {
@@ -54,14 +55,14 @@ model ParticipantResponse {
 }
 
 model ClinicianInvite {
-  id String @id @default(cuid())
-  clinicianFirstName String
+  id                                 String       @id @default(cuid())
+  clinicianFirstName                 String
   clinicianInstitutionalEmailAddress String
-  clinicianLastName String
-  clinicianTitle String
-  consentGroup ConsentGroup
-  consentToBeContacted Boolean
-  inviteSentDate DateTime? @db.Date
-  inviteAcceptedDate DateTime? @db.Date
-  inviteAccepted Boolean?
+  clinicianLastName                  String
+  clinicianTitle                     String
+  consentGroup                       ConsentGroup
+  consentToBeContacted               Boolean
+  inviteSentDate                     DateTime?    @db.Date
+  inviteAcceptedDate                 DateTime?    @db.Date
+  inviteAccepted                     Boolean?
 }

--- a/apps/consent-das/src/routers/participants.ts
+++ b/apps/consent-das/src/routers/participants.ts
@@ -117,6 +117,8 @@ router.get('/:participantId', async (req, res) => {
  *                 type: boolean
  *               isGuardian:
  *                 type: boolean
+ *               consentToBeContacted:
+ *                 type: boolean
  *               consentGroup:
  *                 type: string
  *                 enum:
@@ -130,6 +132,7 @@ router.get('/:participantId', async (req, res) => {
  *             required:
  *               - emailVerified
  *               - isGuardian
+ *               - consentToBeContacted
  *     responses:
  *       201:
  *         description: The participant was successfully created.
@@ -138,13 +141,15 @@ router.get('/:participantId', async (req, res) => {
  */
 router.post('/', async (req, res) => {
 	logger.info('POST /participants');
-	const { emailVerified, isGuardian, consentGroup, guardianIdVerified } = req.body;
+	const { emailVerified, isGuardian, consentGroup, consentToBeContacted, guardianIdVerified } =
+		req.body;
 	// TODO: add validation
 	try {
 		const participant = await createParticipant({
 			emailVerified,
 			isGuardian,
 			consentGroup,
+			consentToBeContacted,
 			guardianIdVerified,
 		});
 		res.status(201).send({ participant });

--- a/apps/consent-das/src/service/create.ts
+++ b/apps/consent-das/src/service/create.ts
@@ -11,11 +11,13 @@ export const createParticipant = async ({
 	emailVerified,
 	isGuardian,
 	consentGroup,
+	consentToBeContacted,
 	guardianIdVerified,
 }: {
 	emailVerified: boolean;
 	isGuardian: boolean;
 	consentGroup?: ConsentGroup;
+	consentToBeContacted: boolean;
 	guardianIdVerified?: boolean;
 }): Promise<Participant> => {
 	// TODO: add error handling
@@ -24,6 +26,7 @@ export const createParticipant = async ({
 			emailVerified,
 			isGuardian,
 			consentGroup,
+			consentToBeContacted,
 			guardianIdVerified,
 		},
 	});

--- a/apps/pi-das/prisma/migrations/20231020190741_set_participant_preferred_name_nullable/migration.sql
+++ b/apps/pi-das/prisma/migrations/20231020190741_set_participant_preferred_name_nullable/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Participant" ALTER COLUMN "participantPreferredName" DROP NOT NULL;

--- a/apps/pi-das/prisma/schema.prisma
+++ b/apps/pi-das/prisma/schema.prisma
@@ -34,7 +34,7 @@ model Participant {
   participantOhipLastName   String
   participantOhipMiddleName String?
   phoneNumber               String           @db.Char(10)
-  participantPreferredName  String
+  participantPreferredName  String?
   guardianName              String?
   guardianPhoneNumber       String?          @db.Char(10)
   guardianEmailAddress      String?
@@ -45,7 +45,6 @@ model Participant {
   mailingAddressPostalCode  String?          @db.Char(6)
   residentialPostalCode     String           @db.Char(6)
 }
-
 
 model ClinicianInvite {
   id                       String        @id @default(cuid())
@@ -60,4 +59,3 @@ model ClinicianInvite {
   guardianRelationship     String?
   Participant              Participant[]
 }
-

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -20,7 +20,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@anatine/zod-openapi": "^2.2.0",
     "eslint-config-ohcrn": "workspace:^",
+    "openapi3-ts": "^4.1.2",
     "zod": "^3.21.4"
   }
 }

--- a/packages/types/src/entities/ParticipantIdentification.ts
+++ b/packages/types/src/entities/ParticipantIdentification.ts
@@ -32,7 +32,7 @@ export const ParticipantIdentification = z
 		id: NanoId,
 		inviteId: NanoId.optional(),
 		ohipNumber: OhipNumber,
-		participantPreferredName: Name,
+		participantPreferredName: Name.optional(),
 		participantOhipFirstName: Name,
 		participantOhipLastName: Name,
 		participantOhipMiddleName: Name.optional(),

--- a/packages/types/src/entities/ParticipantRegistration.ts
+++ b/packages/types/src/entities/ParticipantRegistration.ts
@@ -32,10 +32,10 @@ export const ParticipantRegistration = z
 		keycloakId: z.string().uuid(),
 		inviteId: NanoId.optional(),
 		isGuardian: z.boolean(),
-		participantPreferredName: Name,
+		participantPreferredName: Name.optional(),
 		participantOhipFirstName: Name,
 		participantOhipLastName: Name,
-		dateOfBirth: z.string().datetime(),
+		dateOfBirth: z.coerce.date(),
 		emailAddress: z.string().email(),
 		guardianName: Name.optional(),
 		guardianPhoneNumber: PhoneNumber.optional(),
@@ -71,4 +71,5 @@ export const ParticipantRegistration = z
 
 export type ParticipantRegistration = z.infer<typeof ParticipantRegistration>;
 
-export const ParticipantRegistrationRequest: SchemaObject = generateSchema(ParticipantRegistration);
+export const ParticipantRegistrationOpenAPISchema: SchemaObject =
+	generateSchema(ParticipantRegistration);

--- a/packages/types/src/entities/ParticipantRegistration.ts
+++ b/packages/types/src/entities/ParticipantRegistration.ts
@@ -29,12 +29,13 @@ extendZodWithOpenApi(z);
 
 export const ParticipantRegistration = z
 	.object({
+		keycloakId: z.string().uuid(),
 		inviteId: NanoId.optional(),
 		isGuardian: z.boolean(),
 		participantPreferredName: Name,
 		participantOhipFirstName: Name,
 		participantOhipLastName: Name,
-		dateOfBirth: z.date(),
+		dateOfBirth: z.string().datetime(),
 		emailAddress: z.string().email(),
 		guardianName: Name.optional(),
 		guardianPhoneNumber: PhoneNumber.optional(),
@@ -52,6 +53,7 @@ export const ParticipantRegistration = z
 	})
 	.openapi({
 		example: {
+			keycloakId: '3d7d161e-da15-41f2-b863-a201fb6bb8cc',
 			inviteId: 'TjvI79qhWw1fMKJsaYo497SaOZ30Fc26',
 			isGuardian: true,
 			participantPreferredName: 'Homer',

--- a/packages/types/src/entities/index.ts
+++ b/packages/types/src/entities/index.ts
@@ -23,6 +23,7 @@ export * from './ConsentQuestion.js';
 export * from './Name.js';
 export * from './OhipNumber.js';
 export * from './ParticipantIdentification.js';
+export * from './ParticipantRegistration.js';
 export * from './PhoneNumber.js';
 export * from './PostalCode.js';
 export * from './Province.js';

--- a/packages/types/tests/entities.spec.ts
+++ b/packages/types/tests/entities.spec.ts
@@ -89,6 +89,7 @@ describe('ParticipantIdentification', () => {
 				guardianPhoneNumber: '1234567890',
 				guardianEmailAddress: 'marge.simpson@example.com',
 				guardianRelationship: 'Wife',
+				consentToBeContacted: true,
 			}).success,
 		).true;
 		expect(
@@ -103,6 +104,7 @@ describe('ParticipantIdentification', () => {
 				residentialPostalCode: 'T4B0V7',
 				emailAddress: 'homer.simpson@example.com',
 				consentGroup: ConsentGroup.enum.GUARDIAN_CONSENT_OF_MINOR, // missing all guardian contact fields
+				consentToBeContacted: true,
 			}).success,
 		).false;
 		expect(
@@ -120,6 +122,7 @@ describe('ParticipantIdentification', () => {
 				guardianName: 'Marge Simpson',
 				guardianPhoneNumber: '1234567890',
 				guardianRelationship: 'Wife', // missing guardianEmailAddress
+				consentToBeContacted: true,
 			}).success,
 		).false;
 		expect(
@@ -136,6 +139,7 @@ describe('ParticipantIdentification', () => {
 				consentGroup: ConsentGroup.enum.GUARDIAN_CONSENT_OF_MINOR_INCLUDING_ASSENT,
 				guardianName: 'Marge Simpson',
 				guardianRelationship: 'Wife', // missing guardianPhoneNumber and guardianEmailAddress
+				consentToBeContacted: true,
 			}).success,
 		).false;
 	});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -412,9 +412,15 @@ importers:
 
   packages/types:
     dependencies:
+      '@anatine/zod-openapi':
+        specifier: ^2.2.0
+        version: 2.2.0(openapi3-ts@4.1.2)(zod@3.21.4)
       eslint-config-ohcrn:
         specifier: workspace:^
         version: link:../config/eslint-config-ohcrn
+      openapi3-ts:
+        specifier: ^4.1.2
+        version: 4.1.2
       zod:
         specifier: ^3.21.4
         version: 3.21.4
@@ -432,6 +438,17 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.9
+
+  /@anatine/zod-openapi@2.2.0(openapi3-ts@4.1.2)(zod@3.21.4):
+    resolution: {integrity: sha512-Ponwenf2NMIVbs9IuB3YoW7CQPkuRWxhYV/qxBu48DQhmRyipEw/YROVTWnvku7+lwhv1EyP4+h3J5SwrvmfHg==}
+    peerDependencies:
+      openapi3-ts: ^4.1.2
+      zod: ^3.20.0
+    dependencies:
+      openapi3-ts: 4.1.2
+      ts-deepmerge: 6.2.0
+      zod: 3.21.4
+    dev: false
 
   /@apidevtools/json-schema-ref-parser@9.1.2:
     resolution: {integrity: sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==}
@@ -4103,6 +4120,12 @@ packages:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
     dev: false
 
+  /openapi3-ts@4.1.2:
+    resolution: {integrity: sha512-B7gOkwsYMZO7BZXwJzXCuVagym2xhqsrilVvV0dnq2Di4+iLUXKVX9gOK23ZqaAHZOwABXN0QTdW8QnkUTX6DA==}
+    dependencies:
+      yaml: 2.2.2
+    dev: false
+
   /optionator@0.9.1:
     resolution: {integrity: sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==}
     engines: {node: '>= 0.8.0'}
@@ -5221,6 +5244,11 @@ packages:
     dependencies:
       typescript: 5.2.2
     dev: true
+
+  /ts-deepmerge@6.2.0:
+    resolution: {integrity: sha512-2qxI/FZVDPbzh63GwWIZYE7daWKtwXZYuyc8YNq0iTmMUwn4mL0jRLsp6hfFlgbdRSR4x2ppe+E86FnvEpN7Nw==}
+    engines: {node: '>=14.13.1'}
+    dev: false
 
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}


### PR DESCRIPTION
- Added https://github.com/anatine/zod-plugins/tree/main/packages/zod-openapi to `packages/types` and setup the swagger router config to accept Zod schemas as component schemas in our Swagger JSDocs
- Added the `ParticipantRegistration` Zod schema for the request body of the participant registration form submission/API request
  - `ParticipantRegistrationRequest` is the Open API/Swagger schema (which is for our JSDocs), generated from `ParticipantRegistration`
- Created a `/register` endpoint as a skeleton of the participant registration endpoint with JSDocs to specify the endpoint details
- `participantPreferredName` updated to optional based on Data Model v4.0

Also note, discrepancies between Figma mockup and data model:
- `consentToBeContacted` added since it is in mockup and data model on wiki, not in spreadsheet