### PR TITLE
🗃️ Data Model v4 updates - Consent DAS

### DIFF
--- a/apps/consent-das/prisma/migrations/20231027210340_data_model_v4_update/migration.sql
+++ b/apps/consent-das/prisma/migrations/20231027210340_data_model_v4_update/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `consentGroup` on table `Participant` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "Participant" ALTER COLUMN "consentGroup" SET NOT NULL;

--- a/apps/consent-das/prisma/schema.prisma
+++ b/apps/consent-das/prisma/schema.prisma
@@ -18,7 +18,7 @@ enum ConsentGroup {
 
 model Participant {
   id                  String                @id @default("") @db.Char(21)
-  consentGroup        ConsentGroup?
+  consentGroup        ConsentGroup
   emailVerified       Boolean               @default(false)
   isGuardian          Boolean
   guardianIdVerified  Boolean?

--- a/apps/consent-das/prisma/seed/seed-data.ts
+++ b/apps/consent-das/prisma/seed/seed-data.ts
@@ -1,20 +1,23 @@
-import { Prisma, ConsentCategory } from '../../src/generated/client/index.js';
+import { Prisma, ConsentCategory, ConsentGroup } from '../../src/generated/client/index.js';
 
 const participants: Prisma.ParticipantCreateInput[] = [
 	{
 		id: 'cllgostgz000008l3fk0w',
 		emailVerified: false,
 		isGuardian: false,
+		consentGroup: ConsentGroup.GUARDIAN_CONSENT_OF_MINOR_INCLUDING_ASSENT,
 	},
 	{
 		id: 'cllgoufw3000208l3c6gy',
 		emailVerified: false,
 		isGuardian: false,
+		consentGroup: ConsentGroup.ADULT_CONSENT,
 	},
 	{
 		id: 'cllgouzph000308l35o99',
 		emailVerified: false,
 		isGuardian: false,
+		consentGroup: ConsentGroup.GUARDIAN_CONSENT_OF_MINOR,
 	},
 ];
 

--- a/apps/consent-das/src/service/create.ts
+++ b/apps/consent-das/src/service/create.ts
@@ -16,7 +16,7 @@ export const createParticipant = async ({
 }: {
 	emailVerified: boolean;
 	isGuardian: boolean;
-	consentGroup?: ConsentGroup;
+	consentGroup: ConsentGroup;
 	guardianIdVerified?: boolean;
 	participantId?: string;
 }): Promise<Participant> => {


### PR DESCRIPTION
Changed `consentGroup` field to be not nullable as per Data Model 4.0
  - updated the Prisma schema + seed data
  - updated the `create` service function
  - note that the JSDocs were already listing it as required by default