### PR TITLE
🗃️ Add ConsentQuestionId enum

### DIFF
--- a/apps/consent-das/prisma/migrations/20231031195803_use_consent_question_id_enum/migration.sql
+++ b/apps/consent-das/prisma/migrations/20231031195803_use_consent_question_id_enum/migration.sql
@@ -1,0 +1,29 @@
+/*
+  Warnings:
+
+  - The primary key for the `ConsentQuestion` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `ParticipantResponse` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - Changed the type of `id` on the `ConsentQuestion` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `consentQuestionId` on the `ParticipantResponse` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- CreateEnum
+CREATE TYPE "ConsentQuestionId" AS ENUM ('INFORMED_CONSENT__READ_AND_UNDERSTAND', 'RELEASE_DATA__CLINICAL_AND_GENETIC', 'RELEASE_DATA__DE_IDENTIFIED', 'RESEARCH_PARTICIPATION__FUTURE_RESEARCH', 'RESEARCH_PARTICIPATION__CONTACT_INFORMATION', 'RECONTACT__FUTURE_RESEARCH', 'RECONTACT__SECONDARY_CONTACT', 'REVIEW_SIGN__SIGNED');
+
+-- DropForeignKey
+ALTER TABLE "ParticipantResponse" DROP CONSTRAINT "ParticipantResponse_consentQuestionId_fkey";
+
+-- AlterTable
+ALTER TABLE "ConsentQuestion" DROP CONSTRAINT "ConsentQuestion_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" "ConsentQuestionId" NOT NULL,
+ADD CONSTRAINT "ConsentQuestion_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "ParticipantResponse" DROP CONSTRAINT "ParticipantResponse_pkey",
+DROP COLUMN "consentQuestionId",
+ADD COLUMN     "consentQuestionId" "ConsentQuestionId" NOT NULL,
+ADD CONSTRAINT "ParticipantResponse_pkey" PRIMARY KEY ("id", "participantId", "consentQuestionId");
+
+-- AddForeignKey
+ALTER TABLE "ParticipantResponse" ADD CONSTRAINT "ParticipantResponse_consentQuestionId_fkey" FOREIGN KEY ("consentQuestionId") REFERENCES "ConsentQuestion"("id") ON DELETE RESTRICT ON UPDATE RESTRICT;

--- a/apps/consent-das/prisma/schema.prisma
+++ b/apps/consent-das/prisma/schema.prisma
@@ -33,8 +33,19 @@ enum ConsentCategory {
   CONSENT_REVIEW_SIGN
 }
 
+enum ConsentQuestionId {
+  INFORMED_CONSENT__READ_AND_UNDERSTAND
+  RELEASE_DATA__CLINICAL_AND_GENETIC
+  RELEASE_DATA__DE_IDENTIFIED
+  RESEARCH_PARTICIPATION__FUTURE_RESEARCH
+  RESEARCH_PARTICIPATION__CONTACT_INFORMATION
+  RECONTACT__FUTURE_RESEARCH
+  RECONTACT__SECONDARY_CONTACT
+  REVIEW_SIGN__SIGNED
+}
+
 model ConsentQuestion {
-  id                  String                @id
+  id                  ConsentQuestionId     @id
   isActive            Boolean               @default(true)
   createdAt           DateTime              @default(now())
   category            ConsentCategory
@@ -42,26 +53,26 @@ model ConsentQuestion {
 }
 
 model ParticipantResponse {
-  id                String          @default("") @db.Char(21)
-  participant       Participant     @relation(fields: [participantId], references: [id], onDelete: Restrict, onUpdate: Restrict)
+  id                String            @default("") @db.Char(21)
+  participant       Participant       @relation(fields: [participantId], references: [id], onDelete: Restrict, onUpdate: Restrict)
   participantId     String
-  consentQuestion   ConsentQuestion @relation(fields: [consentQuestionId], references: [id], onDelete: Restrict, onUpdate: Restrict)
-  consentQuestionId String
+  consentQuestion   ConsentQuestion   @relation(fields: [consentQuestionId], references: [id], onDelete: Restrict, onUpdate: Restrict)
+  consentQuestionId ConsentQuestionId
   response          Boolean
-  submittedAt       DateTime        @default(now())
+  submittedAt       DateTime          @default(now())
 
   @@id([id, participantId, consentQuestionId])
 }
 
 model ClinicianInvite {
-  id String @id @default("") @db.Char(21)
-  clinicianFirstName String
+  id                                 String       @id @default("") @db.Char(21)
+  clinicianFirstName                 String
   clinicianInstitutionalEmailAddress String
-  clinicianLastName String
-  clinicianTitleOrRole String
-  consentGroup ConsentGroup
-  consentToBeContacted Boolean
-  inviteSentDate DateTime @db.Date @default(now())
-  inviteAcceptedDate DateTime? @db.Date
-  inviteAccepted Boolean @default(false)
+  clinicianLastName                  String
+  clinicianTitleOrRole               String
+  consentGroup                       ConsentGroup
+  consentToBeContacted               Boolean
+  inviteSentDate                     DateTime     @default(now()) @db.Date
+  inviteAcceptedDate                 DateTime?    @db.Date
+  inviteAccepted                     Boolean      @default(false)
 }

--- a/apps/consent-das/prisma/seed/seed-data.ts
+++ b/apps/consent-das/prisma/seed/seed-data.ts
@@ -1,4 +1,4 @@
-import { Prisma, ConsentCategory, ConsentGroup } from '../../src/generated/client/index.js';
+import { Prisma, ConsentCategory, ConsentGroup, ConsentQuestionId } from '../../src/generated/client/index.js';
 
 const participants: Prisma.ParticipantCreateInput[] = [
 	{
@@ -23,42 +23,42 @@ const participants: Prisma.ParticipantCreateInput[] = [
 
 const consentQuestions: Prisma.ConsentQuestionCreateInput[] = [
 	{
-		id: 'informed-consent__read-and-understand',
+		id: ConsentQuestionId.INFORMED_CONSENT__READ_AND_UNDERSTAND,
 		isActive: true,
 		category: ConsentCategory.INFORMED_CONSENT,
 	},
 	{
-		id: 'release-data__clinical-and-genetic',
+		id: ConsentQuestionId.RELEASE_DATA__CLINICAL_AND_GENETIC,
 		isActive: true,
 		category: ConsentCategory.CONSENT_RELEASE_DATA,
 	},
 	{
-		id: 'release-data__de-identified',
+		id: ConsentQuestionId.RELEASE_DATA__DE_IDENTIFIED,
 		isActive: true,
 		category: ConsentCategory.CONSENT_RELEASE_DATA,
 	},
 	{
-		id: 'research-participation__future-research',
+		id: ConsentQuestionId.RESEARCH_PARTICIPATION__FUTURE_RESEARCH,
 		isActive: true,
 		category: ConsentCategory.CONSENT_RESEARCH_PARTICIPATION,
 	},
 	{
-		id: 'research-participation__contact-information',
+		id: ConsentQuestionId.RESEARCH_PARTICIPATION__CONTACT_INFORMATION,
 		isActive: true,
 		category: ConsentCategory.CONSENT_RESEARCH_PARTICIPATION,
 	},
 	{
-		id: 'recontact__future-research',
+		id: ConsentQuestionId.RECONTACT__FUTURE_RESEARCH,
 		isActive: true,
 		category: ConsentCategory.CONSENT_RECONTACT,
 	},
 	{
-		id: 'recontact__secondary-contact',
+		id: ConsentQuestionId.RECONTACT__SECONDARY_CONTACT,
 		isActive: true,
 		category: ConsentCategory.CONSENT_RECONTACT,
 	},
 	{
-		id: 'review-sign__signed',
+		id: ConsentQuestionId.REVIEW_SIGN__SIGNED,
 		isActive: true,
 		category: ConsentCategory.CONSENT_REVIEW_SIGN,
 	},

--- a/apps/consent-das/src/prismaClient.ts
+++ b/apps/consent-das/src/prismaClient.ts
@@ -26,6 +26,7 @@ import {
 	ConsentCategory,
 	ConsentGroup,
 	ConsentQuestion,
+	ConsentQuestionId,
 	Participant,
 	ParticipantResponse,
 	PrismaClient,
@@ -96,6 +97,7 @@ export {
 	ConsentCategory,
 	ConsentGroup,
 	ConsentQuestion,
+	ConsentQuestionId,
 	Participant,
 	ParticipantResponse,
 };

--- a/apps/consent-das/src/routers/consentQuestions.ts
+++ b/apps/consent-das/src/routers/consentQuestions.ts
@@ -18,9 +18,8 @@
  */
 
 import { Router } from 'express';
-import { ConsentCategory } from 'types/entities';
+import { ConsentCategory, ConsentQuestionId } from 'types/entities';
 
-import { ConsentQuestionId } from '../prismaClient.js';
 import { updateConsentQuestionIsActive } from '../service/update.js';
 import { getConsentQuestion, getConsentQuestions } from '../service/search.js';
 import { createConsentQuestion } from '../service/create.js';
@@ -99,8 +98,7 @@ router.get('/', async (req, res) => {
  *         description: Consent Question ID
  *         required: true
  *         schema:
- *           type: string
- *           TODO: replace with Zod component schema
+ *           $ref: '#/components/schemas/ConsentQuestionId'
  *     responses:
  *       200:
  *         description: The question was successfully retrieved.
@@ -112,7 +110,7 @@ router.get('/:consentQuestionId', async (req, res) => {
 	const { consentQuestionId } = req.params;
 	// TODO: add validation
 	try {
-		const question = await getConsentQuestion(consentQuestionId as ConsentQuestionId); // TODO: remove 'as ConsentQuestionId' and parse with Zod type
+		const question = await getConsentQuestion(ConsentQuestionId.parse(consentQuestionId));
 		res.status(200).send({ question });
 	} catch (error) {
 		logger.error(error);
@@ -138,8 +136,7 @@ router.get('/:consentQuestionId', async (req, res) => {
  *             type: object
  *             properties:
  *               consentQuestionId:
- *                 type: string
- *                 TODO: replace with Zod component schema
+ *                 $ref: '#/components/schemas/ConsentQuestionId'
  *               isActive:
  *                 type: boolean
  *               category:
@@ -179,8 +176,7 @@ router.post('/', async (req, res) => {
  *         description: Consent Question ID
  *         required: true
  *         schema:
- *           type: string
- *           TODO: replace with Zod component schema
+ *           $ref: '#/components/schemas/ConsentQuestionId'
  *     requestBody:
  *       required: true
  *       content:
@@ -200,12 +196,10 @@ router.patch('/:consentQuestionId', async (req, res) => {
 	logger.info('PATCH /consent-questions/:consentQuestionId');
 	const { consentQuestionId } = req.params;
 	const { isActive } = req.body;
-	// TODO: parse with Zod type
-	const parsedConsentQuestionId = consentQuestionId as ConsentQuestionId;
 	// TODO: add validation
 	try {
 		const question = await updateConsentQuestionIsActive({
-			consentQuestionId: parsedConsentQuestionId,
+			consentQuestionId: ConsentQuestionId.parse(consentQuestionId),
 			isActive,
 		});
 		res.status(200).send({ question });

--- a/apps/consent-das/src/routers/consentQuestions.ts
+++ b/apps/consent-das/src/routers/consentQuestions.ts
@@ -110,7 +110,8 @@ router.get('/:consentQuestionId', async (req, res) => {
 	const { consentQuestionId } = req.params;
 	// TODO: add validation
 	try {
-		const question = await getConsentQuestion(ConsentQuestionId.parse(consentQuestionId));
+		const parsedConsentQuestionId = ConsentQuestionId.parse(consentQuestionId);
+		const question = await getConsentQuestion(parsedConsentQuestionId);
 		res.status(200).send({ question });
 	} catch (error) {
 		logger.error(error);
@@ -197,9 +198,10 @@ router.patch('/:consentQuestionId', async (req, res) => {
 	const { consentQuestionId } = req.params;
 	const { isActive } = req.body;
 	// TODO: add validation
+	const parsedConsentQuestionId = ConsentQuestionId.parse(consentQuestionId);
 	try {
 		const question = await updateConsentQuestionIsActive({
-			consentQuestionId: ConsentQuestionId.parse(consentQuestionId),
+			consentQuestionId: parsedConsentQuestionId,
 			isActive,
 		});
 		res.status(200).send({ question });

--- a/apps/consent-das/src/routers/consentQuestions.ts
+++ b/apps/consent-das/src/routers/consentQuestions.ts
@@ -20,6 +20,7 @@
 import { Router } from 'express';
 import { ConsentCategory } from 'types/entities';
 
+import { ConsentQuestionId } from '../prismaClient.js';
 import { updateConsentQuestionIsActive } from '../service/update.js';
 import { getConsentQuestion, getConsentQuestions } from '../service/search.js';
 import { createConsentQuestion } from '../service/create.js';
@@ -99,6 +100,7 @@ router.get('/', async (req, res) => {
  *         required: true
  *         schema:
  *           type: string
+ *           TODO: replace with Zod component schema
  *     responses:
  *       200:
  *         description: The question was successfully retrieved.
@@ -110,7 +112,7 @@ router.get('/:consentQuestionId', async (req, res) => {
 	const { consentQuestionId } = req.params;
 	// TODO: add validation
 	try {
-		const question = await getConsentQuestion(consentQuestionId);
+		const question = await getConsentQuestion(consentQuestionId as ConsentQuestionId); // TODO: remove 'as ConsentQuestionId' and parse with Zod type
 		res.status(200).send({ question });
 	} catch (error) {
 		logger.error(error);
@@ -137,6 +139,7 @@ router.get('/:consentQuestionId', async (req, res) => {
  *             properties:
  *               consentQuestionId:
  *                 type: string
+ *                 TODO: replace with Zod component schema
  *               isActive:
  *                 type: boolean
  *               category:
@@ -177,6 +180,7 @@ router.post('/', async (req, res) => {
  *         required: true
  *         schema:
  *           type: string
+ *           TODO: replace with Zod component schema
  *     requestBody:
  *       required: true
  *       content:
@@ -196,9 +200,14 @@ router.patch('/:consentQuestionId', async (req, res) => {
 	logger.info('PATCH /consent-questions/:consentQuestionId');
 	const { consentQuestionId } = req.params;
 	const { isActive } = req.body;
+	// TODO: parse with Zod type
+	const parsedConsentQuestionId = consentQuestionId as ConsentQuestionId;
 	// TODO: add validation
 	try {
-		const question = await updateConsentQuestionIsActive({ consentQuestionId, isActive });
+		const question = await updateConsentQuestionIsActive({
+			consentQuestionId: parsedConsentQuestionId,
+			isActive,
+		});
 		res.status(200).send({ question });
 	} catch (error) {
 		logger.error(error);

--- a/apps/consent-das/src/routers/participantResponses.ts
+++ b/apps/consent-das/src/routers/participantResponses.ts
@@ -18,8 +18,8 @@
  */
 
 import { Router } from 'express';
+import { ConsentQuestionId } from 'types/entities';
 
-import { ConsentQuestionId } from '../prismaClient.js';
 import { Prisma } from '../generated/client/index.js';
 import { getParticipantResponses } from '../service/search.js';
 import { createParticipantResponse } from '../service/create.js';
@@ -58,8 +58,7 @@ const router = Router();
  *         description: Consent Question ID
  *         required: true
  *         schema:
- *           type: string
- *           TODO: replace with Zod component schema
+ *           $ref: '#/components/schemas/ConsentQuestionId'
  *     responses:
  *       200:
  *         description: The participant responses were successfully retrieved.
@@ -70,12 +69,10 @@ router.get('/:participantId/:consentQuestionId', async (req, res) => {
 	logger.info('GET /participant-responses/:participantId/:consentQuestionId');
 	const { participantId, consentQuestionId } = req.params;
 	const { sort_order } = req.query;
-	// TODO: parse with Zod type
-	const parsedConsentQuestionId = consentQuestionId as ConsentQuestionId;
 	try {
 		const participant_responses = await getParticipantResponses(
 			participantId,
-			parsedConsentQuestionId,
+			ConsentQuestionId.parse(consentQuestionId),
 			// TODO: add validation in getParticipantResponses and fix `as Prisma.SortOrder`
 			sort_order as Prisma.SortOrder | undefined,
 		);
@@ -107,8 +104,8 @@ router.get('/:participantId/:consentQuestionId', async (req, res) => {
  *               participantId:
  *                 type: string
  *               consentQuestionId:
- *                 type: string
- *                 TODO: replace with Zod component schema
+ *                 schema:
+ *                 $ref: '#/components/schemas/ConsentQuestionId'
  *               response:
  *                 type: boolean
  *     responses:

--- a/apps/consent-das/src/routers/participantResponses.ts
+++ b/apps/consent-das/src/routers/participantResponses.ts
@@ -70,9 +70,10 @@ router.get('/:participantId/:consentQuestionId', async (req, res) => {
 	const { participantId, consentQuestionId } = req.params;
 	const { sort_order } = req.query;
 	try {
+		const parsedConsentQuestionId = ConsentQuestionId.parse(consentQuestionId);
 		const participant_responses = await getParticipantResponses(
 			participantId,
-			ConsentQuestionId.parse(consentQuestionId),
+			parsedConsentQuestionId,
 			// TODO: add validation in getParticipantResponses and fix `as Prisma.SortOrder`
 			sort_order as Prisma.SortOrder | undefined,
 		);

--- a/apps/consent-das/src/routers/participantResponses.ts
+++ b/apps/consent-das/src/routers/participantResponses.ts
@@ -105,7 +105,7 @@ router.get('/:participantId/:consentQuestionId', async (req, res) => {
  *                 type: string
  *               consentQuestionId:
  *                 schema:
- *                 $ref: '#/components/schemas/ConsentQuestionId'
+ *                   $ref: '#/components/schemas/ConsentQuestionId'
  *               response:
  *                 type: boolean
  *     responses:

--- a/apps/consent-das/src/routers/participantResponses.ts
+++ b/apps/consent-das/src/routers/participantResponses.ts
@@ -105,8 +105,7 @@ router.get('/:participantId/:consentQuestionId', async (req, res) => {
  *               participantId:
  *                 type: string
  *               consentQuestionId:
- *                 schema:
- *                   $ref: '#/components/schemas/ConsentQuestionId'
+ *                 $ref: '#/components/schemas/ConsentQuestionId'
  *               response:
  *                 type: boolean
  *     responses:

--- a/apps/consent-das/src/routers/participantResponses.ts
+++ b/apps/consent-das/src/routers/participantResponses.ts
@@ -19,6 +19,7 @@
 
 import { Router } from 'express';
 
+import { ConsentQuestionId } from '../prismaClient.js';
 import { Prisma } from '../generated/client/index.js';
 import { getParticipantResponses } from '../service/search.js';
 import { createParticipantResponse } from '../service/create.js';
@@ -58,6 +59,7 @@ const router = Router();
  *         required: true
  *         schema:
  *           type: string
+ *           TODO: replace with Zod component schema
  *     responses:
  *       200:
  *         description: The participant responses were successfully retrieved.
@@ -68,11 +70,12 @@ router.get('/:participantId/:consentQuestionId', async (req, res) => {
 	logger.info('GET /participant-responses/:participantId/:consentQuestionId');
 	const { participantId, consentQuestionId } = req.params;
 	const { sort_order } = req.query;
-
+	// TODO: parse with Zod type
+	const parsedConsentQuestionId = consentQuestionId as ConsentQuestionId;
 	try {
 		const participant_responses = await getParticipantResponses(
 			participantId,
-			consentQuestionId,
+			parsedConsentQuestionId,
 			// TODO: add validation in getParticipantResponses and fix `as Prisma.SortOrder`
 			sort_order as Prisma.SortOrder | undefined,
 		);
@@ -105,6 +108,7 @@ router.get('/:participantId/:consentQuestionId', async (req, res) => {
  *                 type: string
  *               consentQuestionId:
  *                 type: string
+ *                 TODO: replace with Zod component schema
  *               response:
  *                 type: boolean
  *     responses:

--- a/apps/consent-das/src/service/create.ts
+++ b/apps/consent-das/src/service/create.ts
@@ -5,6 +5,7 @@ import prisma, {
 	ConsentGroup,
 	ParticipantResponse,
 	ClinicianInvite,
+	ConsentQuestionId,
 } from '../prismaClient.js';
 
 export const createParticipant = async ({
@@ -38,7 +39,7 @@ export const createConsentQuestion = async ({
 	isActive,
 	category,
 }: {
-	consentQuestionId: string;
+	consentQuestionId: ConsentQuestionId;
 	isActive: boolean;
 	category: ConsentCategory;
 }): Promise<ConsentQuestion> => {
@@ -59,7 +60,7 @@ export const createParticipantResponse = async ({
 	response,
 }: {
 	participantId: string;
-	consentQuestionId: string;
+	consentQuestionId: ConsentQuestionId;
 	response: boolean;
 }): Promise<ParticipantResponse> => {
 	// TODO: add error handling

--- a/apps/consent-das/src/service/search.ts
+++ b/apps/consent-das/src/service/search.ts
@@ -2,6 +2,7 @@ import { Prisma } from '../generated/client/index.js';
 import prisma, {
 	Participant,
 	ConsentQuestion,
+	ConsentQuestionId,
 	ParticipantResponse,
 	ConsentCategory,
 	ClinicianInvite,
@@ -23,7 +24,9 @@ export const getParticipants = async (): Promise<Participant[]> => {
 	return result;
 };
 
-export const getConsentQuestion = async (consentQuestionId: string): Promise<ConsentQuestion> => {
+export const getConsentQuestion = async (
+	consentQuestionId: ConsentQuestionId,
+): Promise<ConsentQuestion> => {
 	// TODO: add error handling
 	const result = await prisma.consentQuestion.findUniqueOrThrow({
 		where: {
@@ -47,7 +50,7 @@ export const getConsentQuestions = async (
 
 export const getParticipantResponses = async (
 	participantId: string,
-	consentQuestionId: string,
+	consentQuestionId: ConsentQuestionId,
 	sortOrder: Prisma.SortOrder = Prisma.SortOrder.desc,
 ): Promise<ParticipantResponse[]> => {
 	// TODO: add error handling

--- a/apps/consent-das/src/service/update.ts
+++ b/apps/consent-das/src/service/update.ts
@@ -1,10 +1,10 @@
-import prisma, { ConsentQuestion } from '../prismaClient.js';
+import prisma, { ConsentQuestion, ConsentQuestionId } from '../prismaClient.js';
 
 export const updateConsentQuestionIsActive = async ({
 	consentQuestionId,
 	isActive,
 }: {
-	consentQuestionId: string;
+	consentQuestionId: ConsentQuestionId;
 	isActive: boolean;
 }): Promise<ConsentQuestion> => {
 	// TODO: add error handling


### PR DESCRIPTION
- Added Consent Question IDs type in consent-das Prisma schema:
```
INFORMED_CONSENT__READ_AND_UNDERSTAND
RELEASE_DATA__CLINICAL_AND_GENETIC
RELEASE_DATA__DE_IDENTIFIED
RESEARCH_PARTICIPATION__FUTURE_RESEARCH
RESEARCH_PARTICIPATION__CONTACT_INFORMATION
RECONTACT__FUTURE_RESEARCH
RECONTACT__SECONDARY_CONTACT
REVIEW_SIGN__SIGNED
```
- updated ConsentQuestion.id and ParticipantResponse.consentQuestionId to use new consent question ID enum
- updated seed-data to use enum values
- updated consent-das services to use new enum values for consent question ids
- create migrations

**Note**: the routers will need to be updated after the `Zod` enum is added