### PR TITLE
✏️ Fix Swagger JSDocs typos

### DIFF
--- a/apps/phi-das/src/routers/clinicalProfiles.ts
+++ b/apps/phi-das/src/routers/clinicalProfiles.ts
@@ -100,7 +100,7 @@ router.get('/:clinicalProfilePrivateKey', async (req, res) => {
  * /clinical-profiles/:
  *   post:
  *     tags:
- *       - Clinical Profile
+ *       - Clinical Profiles
  *     name: Create Clinical Profile
  *     description: Create one clinical profile
  *     security:

--- a/apps/pi-das/src/routers/clinicianInvites.ts
+++ b/apps/pi-das/src/routers/clinicianInvites.ts
@@ -100,8 +100,8 @@ router.get('/:inviteId', async (req, res) => {
  * /clinician-invites/:
  *   post:
  *     tags:
- *       - Participant
- *     name: Create Participant
+ *       - Clinician Invites
+ *     name: Create Clinician Invite
  *     description: Create one clinician invite
  *     security:
  *       - bearerAuth: []

--- a/apps/pi-das/src/routers/participants.ts
+++ b/apps/pi-das/src/routers/participants.ts
@@ -101,7 +101,7 @@ router.get('/:participantId', async (req, res) => {
  * /participants/:
  *   post:
  *     tags:
- *       - Participant
+ *       - Participants
  *     name: Create Participant
  *     description: Create one participant
  *     security:
@@ -219,7 +219,7 @@ router.post('/', async (req, res) => {
  * /participants/{participantId}:
  *   patch:
  *     tags:
- *       - Participant
+ *       - Participants
  *     name: Update Participant
  *     description: Update participant by ID
  *     security:


### PR DESCRIPTION
- fixed some typos in a couple of the Swagger JSDocs `tag` fields which led to some of the router endpoints being grouped in two spots in the Swagger UI (like some under Participant and others under Participants)