### PR TITLE
🚑️ Omit inviteSentDate in Clinician Invite services

### DIFF
--- a/apps/consent-das/prisma/seed/seed-data.ts
+++ b/apps/consent-das/prisma/seed/seed-data.ts
@@ -73,7 +73,6 @@ const clinicianInvites: Prisma.ClinicianInviteCreateInput[] = [
 		clinicianTitleOrRole: 'Neurosurgeon',
 		consentGroup: 'ADULT_CONSENT',
 		consentToBeContacted: true,
-		inviteSentDate: new Date('2023-10-03'),
 	},
 ];
 

--- a/apps/consent-das/src/routers/clinicianInvites.ts
+++ b/apps/consent-das/src/routers/clinicianInvites.ts
@@ -132,10 +132,6 @@ router.get('/:inviteId', async (req, res) => {
  *               consentToBeContacted:
  *                 type: boolean
  *                 required: true
- *               inviteSentDate:
- *                 type: string
- *                 format: date
- *                 required: true
  *               inviteAcceptedDate:
  *                 type: string
  *                 format: date
@@ -159,13 +155,11 @@ router.post('/', async (req, res) => {
 		clinicianTitleOrRole,
 		consentGroup,
 		consentToBeContacted,
-		inviteSentDate,
 		inviteAcceptedDate,
 		inviteAccepted,
 	} = req.body;
 	// TODO: add validation
 	try {
-		const parsedInviteSentDate = new Date(inviteSentDate);
 		const parsedInviteAcceptedDate = inviteAcceptedDate ? new Date(inviteAcceptedDate) : undefined;
 		const clinicianInvite = await createClinicianInvite({
 			clinicianFirstName,
@@ -175,7 +169,6 @@ router.post('/', async (req, res) => {
 			clinicianTitleOrRole,
 			consentGroup,
 			consentToBeContacted,
-			inviteSentDate: parsedInviteSentDate,
 			inviteAcceptedDate: parsedInviteAcceptedDate,
 			inviteAccepted,
 		});

--- a/apps/consent-das/src/service/create.ts
+++ b/apps/consent-das/src/service/create.ts
@@ -89,7 +89,6 @@ export const createClinicianInvite = async ({
 	clinicianTitleOrRole,
 	consentGroup,
 	consentToBeContacted,
-	inviteSentDate,
 	inviteAcceptedDate,
 	inviteAccepted,
 }: {
@@ -100,7 +99,6 @@ export const createClinicianInvite = async ({
 	clinicianTitleOrRole: string;
 	consentGroup: ConsentGroup;
 	consentToBeContacted: boolean;
-	inviteSentDate: Date;
 	inviteAcceptedDate?: Date;
 	inviteAccepted?: boolean;
 }): Promise<ClinicianInvite> => {
@@ -114,7 +112,6 @@ export const createClinicianInvite = async ({
 			consentGroup,
 			consentToBeContacted,
 			id: clinicianInviteId,
-			inviteSentDate,
 			inviteAcceptedDate,
 			inviteAccepted,
 		},


### PR DESCRIPTION
- leftover instances of `inviteSentDate` that I didn't catch in #214