### PR TITLE
⚡️ enforce server-only usage for getTranslation

### DIFF
--- a/apps/consent-ui/package.json
+++ b/apps/consent-ui/package.json
@@ -23,6 +23,7 @@
 		"react-dom": "18.2.0",
 		"react-google-recaptcha": "^3.1.0",
 		"sass": "^1.64.0",
+		"server-only": "^0.0.1",
 		"sharp": "^0.32.6",
 		"tailwindcss": "3.3.2",
 		"types": "workspace:^",

--- a/apps/consent-ui/src/components/Footer/APIVersion.tsx
+++ b/apps/consent-ui/src/components/Footer/APIVersion.tsx
@@ -21,12 +21,11 @@
 
 import { useEffect, useState } from 'react';
 
-import { ValidLanguage } from 'src/i18n';
 import { getAPIStatus } from 'src/services/api';
 
-import APIVersionLabel from './APIVersionLabel';
+import { TranslationWithInterpolation } from '../TranslationWithInterpolation';
 
-const APIVersion = ({ currentLang }: { currentLang: ValidLanguage }) => {
+const APIVersion = ({ versionText }: { versionText: string }) => {
 	const [apiVersion, setApiVersion] = useState<string>('N/A');
 
 	useEffect(() => {
@@ -37,7 +36,7 @@ const APIVersion = ({ currentLang }: { currentLang: ValidLanguage }) => {
 		fetchData();
 	}, []);
 
-	return <APIVersionLabel apiVersion={apiVersion} currentLang={currentLang} />;
+	return <TranslationWithInterpolation translatedText={versionText} parameters={{ apiVersion }} />;
 };
 
 export default APIVersion;

--- a/apps/consent-ui/src/components/Footer/Versions.tsx
+++ b/apps/consent-ui/src/components/Footer/Versions.tsx
@@ -51,7 +51,7 @@ const Versions = async ({ currentLang }: { currentLang: ValidLanguage }) => {
 					{translate('footer', 'ohcrn-registry', { registryVersion: packageJson.version })} -{' '}
 				</span>
 				<Suspense fallback={<span />}>
-					<APIVersion currentLang={currentLang} />
+					<APIVersion versionText={translate('footer', 'api')} />
 				</Suspense>
 			</div>
 		</div>

--- a/apps/consent-ui/src/components/Header/HeaderWrapper.tsx
+++ b/apps/consent-ui/src/components/Header/HeaderWrapper.tsx
@@ -22,6 +22,7 @@
 import clsx from 'clsx';
 import { ReactNode } from 'react';
 import { usePathname } from 'next/navigation';
+
 import { ValidLanguage } from 'src/i18n';
 
 import { getLinkNameByPath } from '../Link/utils';

--- a/apps/consent-ui/src/components/Header/index.tsx
+++ b/apps/consent-ui/src/components/Header/index.tsx
@@ -19,6 +19,7 @@
 
 import Link from 'next/link';
 import Image, { StaticImageData } from 'next/image';
+
 import { ValidLanguage, getTranslation } from 'src/i18n';
 import { defaultLanguage } from 'src/i18n/settings';
 import LanguageToggle from 'src/components/Header/LanguageToggle';

--- a/apps/consent-ui/src/components/TranslationWithInterpolation.tsx
+++ b/apps/consent-ui/src/components/TranslationWithInterpolation.tsx
@@ -17,17 +17,16 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { getTranslation, ValidLanguage } from 'src/i18n';
+import { replaceParams } from 'src/i18n/utils/replaceParams';
 
-const APIVersionLabel = async ({
-	apiVersion,
-	currentLang,
+export const TranslationWithInterpolation = ({
+	translatedText,
+	parameters,
 }: {
-	apiVersion: string;
-	currentLang: ValidLanguage;
+	translatedText: string;
+	parameters: Record<string, string | number>;
 }) => {
-	const translate = getTranslation(currentLang);
-	return <span>{translate('footer', 'api', { apiVersion })}</span>;
+	return <span>{replaceParams(translatedText, parameters)}</span>;
 };
 
-export default APIVersionLabel;
+export default TranslationWithInterpolation;

--- a/apps/consent-ui/src/i18n/utils/getTranslation.ts
+++ b/apps/consent-ui/src/i18n/utils/getTranslation.ts
@@ -16,44 +16,14 @@
  * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-import { REGEX_FLAG_GLOBAL } from 'types/entities';
+
+import 'server-only';
 
 import { GetTranslation } from 'src/i18n/types';
 import dictionaries from 'src/i18n/locales';
 
-/**
- * ```
- * Util function that takes the parameters object passed in to the function returned from getTranslation()
- * and replaces the key in the translated string with the value of that key
- * Regex will ignore whitespace between the {{/}} and the tag, so {{key}} and {{ key }} and all other permutations of spaces are matched
- * Uses the global regex flag to ensure each instance of an argument key in a string is replaced
- *
- * ```
- * @param original
- * @param replacements
- * @returns string
- * @example
- * const dict = {
- * 	common: {
- * 		'sample-sentence': 'Translated this string on a {{dayOfWeek}} in {{ dayOfMonth }}.'
- * 	}
- * }
- * const translate = getTranslation('en')
- * translate('common', 'sample-sentence', { dayOfWeek: 'Thursday', dayOfMonth: 'October' }) would call replaceParams as:
- * replaceParams('Translated this string on a {{dayOfWeek}} in {{ dayOfMonth }}.', { dayOfWeek: 'Thursday', dayOfMonth: 'October' } )
- * // returns 'Translated this string on a Thursday in October.'
- */
-const replaceParams = (
-	original: string,
-	replacements?: Record<string, string | number>,
-): string => {
-	return Object.entries(replacements || {}).reduce((acc, [key, value]) => {
-		const tagRegex = new RegExp(`{{[\\s]*${key}[\\s]*}}`, REGEX_FLAG_GLOBAL);
-		return acc.replace(tagRegex, String(value));
-	}, original);
-};
+import { replaceParams } from './replaceParams';
 
-// TODO: is there a way to enforce this function for server side use only?
 export const getTranslation: GetTranslation = (language) => {
 	const dictionary = dictionaries[language];
 	return (namespace, key, params) => {

--- a/apps/consent-ui/src/i18n/utils/replaceParams.ts
+++ b/apps/consent-ui/src/i18n/utils/replaceParams.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { REGEX_FLAG_GLOBAL } from 'types/entities';
+
+/**
+ * ```
+ * Util function that takes the parameters object passed in to the function returned from getTranslation()
+ * and replaces the key in the translated string with the value of that key
+ * Regex will ignore whitespace between the {{/}} and the tag, so {{key}} and {{ key }} and all other permutations of spaces are matched
+ * Uses the global regex flag to ensure each instance of an argument key in a string is replaced
+ *
+ * ```
+ * @param original
+ * @param replacements
+ * @returns string
+ * @example
+ * const dict = {
+ * 	common: {
+ * 		'sample-sentence': 'Translated this string on a {{dayOfWeek}} in {{ dayOfMonth }}.'
+ * 	}
+ * }
+ * const translate = getTranslation('en')
+ * translate('common', 'sample-sentence', { dayOfWeek: 'Thursday', dayOfMonth: 'October' }) would call replaceParams as:
+ * replaceParams('Translated this string on a {{dayOfWeek}} in {{ dayOfMonth }}.', { dayOfWeek: 'Thursday', dayOfMonth: 'October' } )
+ * // returns 'Translated this string on a Thursday in October.'
+ */
+export const replaceParams = (
+	original: string,
+	replacements?: Record<string, string | number>,
+): string => {
+	return Object.entries(replacements || {}).reduce((acc, [key, value]) => {
+		const tagRegex = new RegExp(`{{[\\s]*${key}[\\s]*}}`, REGEX_FLAG_GLOBAL);
+		return acc.replace(tagRegex, String(value));
+	}, original);
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -186,6 +186,9 @@ importers:
       sass:
         specifier: ^1.64.0
         version: 1.64.0
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
       sharp:
         specifier: ^0.32.6
         version: 0.32.6
@@ -4759,6 +4762,10 @@ packages:
       send: 0.18.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
     dev: false
 
   /set-blocking@2.0.0:


### PR DESCRIPTION
Adds `server-only` import to `getTranslation` util file to prevent use in client components, so dictionaries are not imported on the client.
- pulls `replaceParams` into its own utils file so it can be used independently of `getTranslation`, and can be used as necessary on the client
- adds a simple component `TranslationWithInterpolation` (name TBD, what i have can prob be improved 🙂 ) that takes a translated string + params and returns a `span` element with the fully interpolated string. This is for use in components that require parameters coming from data fetches in client components or their children, as `getTranslation` cannot be called in those components.
- refactors `ApiVersion` components to use this new setup

If this looks like a good approach to you @mistryrn I will update the dictionary docs to include this setup!