### PR TITLE
PR Feedback - Suggestion for re-organizing Clinician Invite types

### DIFF
--- a/packages/types/src/entities/ClinicianInvite/ClinicianInvite.ts
+++ b/packages/types/src/entities/ClinicianInvite/ClinicianInvite.ts
@@ -27,80 +27,50 @@ import { PhoneNumber } from '../PhoneNumber.js';
 import { NanoId } from '../NanoId.js';
 import { hasRequiredGuardianInformation } from '../ParticipantIdentification.js';
 
-export const ClinicianInviteBase = z.object({
+export const InviteClinicianFields = z.object({
+	clinicianFirstName: Name,
+	clinicianInstitutionalEmailAddress: z.string().email(),
+	clinicianLastName: Name,
+	clinicianTitleOrRole: z.string().trim().min(1),
+	consentGroup: ConsentGroup,
+	consentToBeContacted: z.literal(true),
+});
+export type InviteClinicianFields = z.infer<typeof InviteClinicianFields>;
+
+export const InviteGuardianFields = z.object({
+	guardianEmailAddress: z.string().email().optional(),
+	guardianName: Name.optional(),
+	guardianPhoneNumber: PhoneNumber.optional(),
+	guardianRelationship: Name.optional(),
+});
+export type InviteGuardianFields = z.infer<typeof InviteGuardianFields>;
+
+export const InviteParticipantFields = z.object({
+	participantEmailAddress: z.string().email(),
+	participantFirstName: Name,
+	participantLastName: Name,
+	participantPhoneNumber: PhoneNumber,
+	participantPreferredName: Name.optional(),
+});
+export type InviteParticipantFields = z.infer<typeof InviteParticipantFields>;
+
+export const InviteEntity = z.object({
 	id: NanoId,
+
 	inviteSentDate: z.coerce.date(),
 	inviteAcceptedDate: z.coerce.date().optional(),
 	inviteAccepted: z.boolean().default(false),
-	clinicianFirstName: Name,
-	clinicianLastName: Name,
-	clinicianInstitutionalEmailAddress: z.string().email(),
-	clinicianTitleOrRole: z.string().trim().min(1),
-	participantFirstName: Name,
-	participantLastName: Name,
-	participantEmailAddress: z.string().email(),
-	participantPhoneNumber: PhoneNumber,
-	participantPreferredName: Name.optional(),
-	consentGroup: ConsentGroup,
-	guardianName: Name.optional(),
-	guardianPhoneNumber: PhoneNumber.optional(),
-	guardianEmailAddress: z.string().email().optional(),
-	guardianRelationship: Name.optional(),
-	consentToBeContacted: z.literal(true),
 });
 
-export const ClinicianInviteRequest = ClinicianInviteBase.pick({
-	clinicianFirstName: true,
-	clinicianLastName: true,
-	clinicianInstitutionalEmailAddress: true,
-	clinicianTitleOrRole: true,
-	participantFirstName: true,
-	participantLastName: true,
-	participantEmailAddress: true,
-	participantPhoneNumber: true,
-	participantPreferredName: true,
-	consentGroup: true,
-	guardianName: true,
-	guardianPhoneNumber: true,
-	guardianEmailAddress: true,
-	guardianRelationship: true,
-	consentToBeContacted: true,
-}).refine((input) => {
-	const {
-		consentGroup,
-		guardianName,
-		guardianPhoneNumber,
-		guardianEmailAddress,
-		guardianRelationship,
-	} = input;
-	return hasRequiredGuardianInformation(
-		consentGroup,
-		guardianName,
-		guardianPhoneNumber,
-		guardianEmailAddress,
-		guardianRelationship,
-	);
-});
-
+export const ClinicianInviteRequest = InviteClinicianFields.merge(InviteGuardianFields)
+	.merge(InviteParticipantFields)
+	.refine(hasRequiredGuardianInformation);
 export type ClinicianInviteRequest = z.infer<typeof ClinicianInviteRequest>;
 export const ClinicianInviteRequestSchema: SchemaObject = generateSchema(ClinicianInviteRequest);
 
-export const ClinicianInviteResponse = ClinicianInviteBase.refine((input) => {
-	const {
-		consentGroup,
-		guardianName,
-		guardianPhoneNumber,
-		guardianEmailAddress,
-		guardianRelationship,
-	} = input;
-	return hasRequiredGuardianInformation(
-		consentGroup,
-		guardianName,
-		guardianPhoneNumber,
-		guardianEmailAddress,
-		guardianRelationship,
-	);
-});
+export const ClinicianInvite = InviteEntity.and(ClinicianInviteRequest);
+export type ClinicianInvite = z.infer<typeof ClinicianInvite>;
 
+export const ClinicianInviteResponse = ClinicianInvite;
 export type ClinicianInviteResponse = z.infer<typeof ClinicianInviteResponse>;
 export const ClinicianInviteResponseSchema: SchemaObject = generateSchema(ClinicianInviteResponse);

--- a/packages/types/src/entities/ClinicianInvite/ConsentClinicianInvite.ts
+++ b/packages/types/src/entities/ClinicianInvite/ConsentClinicianInvite.ts
@@ -21,35 +21,16 @@ import { z } from 'zod';
 import { generateSchema } from '@anatine/zod-openapi';
 import { SchemaObject } from 'openapi3-ts/oas31';
 
-import { ClinicianInviteBase } from './ClinicianInvite.js';
+import { ClinicianInvite, InviteClinicianFields, InviteEntity } from './ClinicianInvite.js';
+import { NanoId } from '../NanoId.js';
 
-export const ConsentClinicianInviteRequest = ClinicianInviteBase.pick({
-	id: true,
-	clinicianFirstName: true,
-	clinicianLastName: true,
-	clinicianInstitutionalEmailAddress: true,
-	clinicianTitleOrRole: true,
-	consentGroup: true,
-	consentToBeContacted: true,
-});
-
+export const ConsentClinicianInviteRequest = z.object({ id: NanoId }).merge(InviteClinicianFields);
 export type ConsentClinicianInviteRequest = z.infer<typeof ConsentClinicianInviteRequest>;
 export const ConsentClinicianInviteRequestSchema: SchemaObject = generateSchema(
 	ConsentClinicianInviteRequest,
 );
 
-export const ConsentClinicianInviteResponse = ClinicianInviteBase.pick({
-	id: true,
-	inviteSentDate: true,
-	inviteAcceptedDate: true,
-	inviteAccepted: true,
-	clinicianFirstName: true,
-	clinicianLastName: true,
-	clinicianInstitutionalEmailAddress: true,
-	clinicianTitleOrRole: true,
-	consentGroup: true,
-	consentToBeContacted: true,
-}).extend({
+export const ConsentClinicianInviteResponse = InviteEntity.merge(InviteClinicianFields).extend({
 	inviteAcceptedDate: z.coerce
 		.date()
 		.nullable()

--- a/packages/types/src/entities/ClinicianInvite/PIClinicianInvite.ts
+++ b/packages/types/src/entities/ClinicianInvite/PIClinicianInvite.ts
@@ -24,36 +24,16 @@ import { SchemaObject } from 'openapi3-ts/oas31';
 import { Name } from '../Name.js';
 import { PhoneNumber } from '../PhoneNumber.js';
 
-import { ClinicianInviteBase } from './ClinicianInvite.js';
+import { InviteGuardianFields, InviteParticipantFields } from './ClinicianInvite.js';
+import { NanoId } from '../NanoId.js';
 
-export const PIClinicianInviteRequest = ClinicianInviteBase.pick({
-	participantFirstName: true,
-	participantLastName: true,
-	participantEmailAddress: true,
-	participantPhoneNumber: true,
-	participantPreferredName: true,
-	guardianName: true,
-	guardianPhoneNumber: true,
-	guardianEmailAddress: true,
-	guardianRelationship: true,
-});
+export const PIClinicianInviteRequest = InviteParticipantFields.merge(InviteGuardianFields);
 
 export type PIClinicianInviteRequest = z.infer<typeof PIClinicianInviteRequest>;
 export const PIClinicianInviteRequestSchema: SchemaObject =
 	generateSchema(PIClinicianInviteRequest);
 
-export const PIClinicianInviteResponse = ClinicianInviteBase.pick({
-	id: true,
-	participantFirstName: true,
-	participantLastName: true,
-	participantEmailAddress: true,
-	participantPhoneNumber: true,
-	participantPreferredName: true,
-	guardianName: true,
-	guardianPhoneNumber: true,
-	guardianEmailAddress: true,
-	guardianRelationship: true,
-}).extend({
+export const PIClinicianInviteResponse = PIClinicianInviteRequest.extend({ id: NanoId }).extend({
 	participantPreferredName: Name.nullable().transform((input) => input ?? undefined),
 	guardianName: Name.nullable().transform((input) => input ?? undefined),
 	guardianPhoneNumber: PhoneNumber.nullable().transform((input) => input ?? undefined),

--- a/packages/types/src/entities/ParticipantIdentification.ts
+++ b/packages/types/src/entities/ParticipantIdentification.ts
@@ -27,16 +27,24 @@ import { Name } from './Name.js';
 import { OhipNumber } from './OhipNumber.js';
 import { NanoId } from './NanoId.js';
 import { LifecycleState } from './LifecycleState.js';
+import { InviteGuardianFields } from './index.js';
 
 export const hasRequiredGuardianInformation = (
-	consentGroup: ConsentGroup,
-	guardianName?: Name,
-	guardianPhoneNumber?: PhoneNumber,
-	guardianEmailAddress?: string,
-	guardianRelationship?: Name,
+	props: {
+		consentGroup: ConsentGroup;
+	} & InviteGuardianFields,
 ) => {
 	// guardianName, guardianPhoneNumber, guardianEmailAddress, guardianRelationship must be defined if
 	// ConsentGroup.GUARDIAN_CONSENT_OF_MINOR or ConsentGroup.GUARDIAN_CONSENT_OF_MINOR_INCLUDING_ASSENT was selected
+
+	const {
+		consentGroup,
+		guardianName,
+		guardianPhoneNumber,
+		guardianEmailAddress,
+		guardianRelationship,
+	} = props;
+
 	const requiresGuardianInformation =
 		consentGroup === ConsentGroup.enum.GUARDIAN_CONSENT_OF_MINOR ||
 		consentGroup === ConsentGroup.enum.GUARDIAN_CONSENT_OF_MINOR_INCLUDING_ASSENT;
@@ -73,21 +81,6 @@ export const ParticipantIdentification = z
 		guardianEmailAddress: z.string().email().optional(),
 		guardianRelationship: Name.optional(),
 	})
-	.refine((input) => {
-		const {
-			consentGroup,
-			guardianName,
-			guardianPhoneNumber,
-			guardianEmailAddress,
-			guardianRelationship,
-		} = input;
-		return hasRequiredGuardianInformation(
-			consentGroup,
-			guardianName,
-			guardianPhoneNumber,
-			guardianEmailAddress,
-			guardianRelationship,
-		);
-	});
+	.refine(hasRequiredGuardianInformation);
 
 export type ParticipantIdentification = z.infer<typeof ParticipantIdentification>;


### PR DESCRIPTION
## Description of Changes

Refactor suggestions for https://github.com/OHCRN/platform/pull/235

Reworks the ClinicianInvite types file into multiple composable types.

The invite is broken in the following sections:
- `InviteClinicianFields`
- `InviteGuardianFields`
- `InviteParticipantFields`
- `InviteEntity`

Which are then composed as:
- `ClinicianInviteRequest` = (`InviteClinicianFields` & `InviteGuardianFields` & `InviteParticipantFields`) + guardian refinement
- `ClinicianInviteResponse` = `InviteEntity` & `ClinicianInviteRequest`

A couple entities used in DAS requests were also reworked to use these components:
- `ConsentClinicianInviteRequest` = `{id}` & `InviteClinicianFields`
- `PIClinicianInviteRequest` = `InviteParticipantFields` & `InviteGuardianFields`
