### PR TITLE
🦺 PI DAS error handling for Clinician Invite flow (#275)

### DIFF
--- a/apps/consent-api/src/routers/invites.ts
+++ b/apps/consent-api/src/routers/invites.ts
@@ -92,7 +92,7 @@ router.post(
 			}
 		} catch (error) {
 			logger.error('POST /invites', `Unexpected error handling create invite request.`, error);
-			res.status(500).send(ErrorResponse(SERVER_ERROR, 'An unexpected error occurred'));
+			return res.status(500).send(ErrorResponse(SERVER_ERROR, 'An unexpected error occurred'));
 		}
 	}),
 );

--- a/apps/data-mapper/src/services/das/pi.ts
+++ b/apps/data-mapper/src/services/das/pi.ts
@@ -49,7 +49,7 @@ export const createInvitePiData = async ({
 			guardianRelationship,
 		});
 		// converts all nulls to undefined
-		return PIClinicianInviteResponse.parse(result.data.invite);
+		return PIClinicianInviteResponse.parse(result.data);
 	} catch (error) {
 		logger.error(error);
 		throw error; // TODO: remove and send custom error schema

--- a/apps/pi-das/package.json
+++ b/apps/pi-das/package.json
@@ -22,8 +22,9 @@
 	"dependencies": {
 		"@prisma/client": "^5.1.1",
 		"body-parser": "^1.20.2",
-		"express-error-handler": "workspace:^",
 		"express": "^4.18.2",
+		"express-error-handler": "workspace:^",
+		"express-request-validation": "workspace:^",
 		"logger": "workspace:^",
 		"nanoid": "^5.0.2",
 		"types": "workspace:^"

--- a/apps/pi-das/src/routers/clinicianInvites.ts
+++ b/apps/pi-das/src/routers/clinicianInvites.ts
@@ -148,7 +148,7 @@ router.post(
 			}
 		} catch (error) {
 			logger.error('POST /invites', `Unexpected error handling create invite request.`, error);
-			res.status(500).send(ErrorResponse(SERVER_ERROR, 'An unexpected error occurred'));
+			return res.status(500).send(ErrorResponse(SERVER_ERROR, 'An unexpected error occurred'));
 		}
 	}),
 );

--- a/apps/pi-das/src/routers/swagger.ts
+++ b/apps/pi-das/src/routers/swagger.ts
@@ -20,6 +20,10 @@
 import { Router } from 'express';
 import { serve, setup } from 'swagger-ui-express';
 import swaggerJsdoc from 'swagger-jsdoc';
+import {
+	PIClinicianInviteRequestSchema as ClinicianInviteRequest,
+	PIClinicianInviteResponseSchema as ClinicianInviteResponse,
+} from 'types/entities';
 
 import packageJson from '../../package.json' assert { type: 'json' };
 
@@ -61,6 +65,12 @@ const options = swaggerJsdoc({
 					url: '/',
 				},
 			],
+		},
+		components: {
+			schemas: {
+				ClinicianInviteRequest,
+				ClinicianInviteResponse,
+			},
 		},
 	},
 	apis: ['./src/routers/*'],

--- a/apps/pi-das/src/service/create.ts
+++ b/apps/pi-das/src/service/create.ts
@@ -1,4 +1,11 @@
+import { PIClinicianInviteRequest } from 'types/entities';
+import { Result, failure, success } from 'types/httpResponses';
+
 import prisma, { Participant, Province, ClinicianInvite } from '../prismaClient.js';
+import { PrismaClientKnownRequestError } from '../generated/client/runtime/library.js';
+import serviceLogger from '../logger.js';
+
+const logger = serviceLogger.forModule('PrismaClient');
 
 export const createParticipant = async ({
 	inviteId,
@@ -65,42 +72,37 @@ export const createParticipant = async ({
 	return result;
 };
 
-export const createClinicianInvite = async ({
-	participantFirstName,
-	participantLastName,
-	participantEmailAddress,
-	participantPhoneNumber,
-	participantPreferredName,
-	guardianName,
-	guardianPhoneNumber,
-	guardianEmailAddress,
-	guardianRelationship,
-	clinicianInviteId,
-}: {
-	participantFirstName: string;
-	participantLastName: string;
-	participantEmailAddress: string;
-	participantPhoneNumber: string;
-	participantPreferredName?: string;
-	guardianName?: string;
-	guardianPhoneNumber?: string;
-	guardianEmailAddress?: string;
-	guardianRelationship?: string;
-	clinicianInviteId?: string;
-}): Promise<ClinicianInvite> => {
-	const result = await prisma.clinicianInvite.create({
-		data: {
-			participantFirstName,
-			participantLastName,
-			participantEmailAddress,
-			participantPhoneNumber,
-			participantPreferredName,
-			guardianName,
-			guardianPhoneNumber,
-			guardianEmailAddress,
-			guardianRelationship,
-			id: clinicianInviteId,
-		},
-	});
-	return result;
+type CreateInviteFailureStatus = 'SYSTEM_ERROR' | 'INVITE_EXISTS';
+/**
+ * Creates a ClinicianInvite entry in the PI DB
+ * @param inviteRequest Clinician Invite data
+ * @returns ClinicianInvite object from PI DB
+ */
+export const createClinicianInvite = async (
+	inviteRequest: PIClinicianInviteRequest,
+): Promise<Result<ClinicianInvite, CreateInviteFailureStatus>> => {
+	return await prisma.clinicianInvite
+		.create({
+			data: inviteRequest,
+		})
+		.then(
+			(invite) => success(invite),
+			(error) => {
+				if (error instanceof PrismaClientKnownRequestError && error.code === 'P2002') {
+					// Prisma error code P2002 indicates "Unique constraint failed"
+					// See docs: https://www.prisma.io/docs/reference/api-reference/error-reference#p2002
+					logger.info('POST /invites', 'Unique constraint failed creating invite.', error.message);
+					return failure(
+						'INVITE_EXISTS',
+						`An invite already exists with that '${error.meta?.target ?? 'data'}'`,
+					);
+				}
+				logger.error(
+					'POST /invites',
+					'Unexpected error handling create invite request.',
+					error.message,
+				);
+				return failure('SYSTEM_ERROR', 'An unexpected error occurred.');
+			},
+		);
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -352,6 +352,9 @@ importers:
       express-error-handler:
         specifier: workspace:^
         version: link:../../packages/express-error-handler
+      express-request-validation:
+        specifier: workspace:^
+        version: link:../../packages/express-request-validation
       logger:
         specifier: workspace:^
         version: link:../../packages/logger


### PR DESCRIPTION
## Description of Changes

Implemented complete error handling, validation, and logging for the `POST /invites` router and `createClinicianInvite` service in PI DAS using `consent-api` as an example.

### PI DAS
- Added `express-request-validation` from shared packages to use `withRequestValidation` to validate the endpoint's request body
- Updated the endpoint's HTTP Responses to use the appropriate `ErrorResponse`
- Added a 400 RequestValidationError and 409 ConflictError to the endpoint responses, updated the JSDocs
- Updated the return type of the `createClinicianInvite` service to `Result` so it returns appropriate `Success` and `Failure` responses to the router
- Updated the Prisma create request so it returns a failure response if an error occurred
>**Note:** The parameter type for `createClinicianInvite` was changed to the Zod schema `PIClinicianInvite` so it no longer uses the `clinicianId` field if a manually generated ID is being passed to it

### Special Instructions
Before running these changes, you will need to add `express-request-validation` to PI DAS:
```
pnpm i
```

## PR Readiness Checklist

- [x] "Expected Outcome(s)" in ticket have been met
- [x] Ticket number included in PR title
- [x] Connected ticket to PR
- [x] Labels added to PR for service name (`consent-api`, `data-mapper`, etc...), type (`chore`, `documentation`, etc...), status (`draft`, `on-hold`, etc...) **if applicable**
- [x] Manual testing completed
- [x] Builds locally without errors or warnings
- [x] Tests are updated (if required) and passing
- [ ] PR feedback has been addressed **if applicable**
- [ ] New environment variables added to `.env.schema` files, `README.md`
- [ ] Added copyrights to new files
