### PR TITLE
🦺 Consent DAS error handling for Clinician Invite flow (#275)

### DIFF
--- a/apps/consent-das/package.json
+++ b/apps/consent-das/package.json
@@ -22,8 +22,9 @@
 	"dependencies": {
 		"@prisma/client": "^5.1.1",
 		"body-parser": "^1.20.2",
-		"express-error-handler": "workspace:^",
 		"express": "^4.18.2",
+		"express-error-handler": "workspace:^",
+		"express-request-validation": "workspace:^",
 		"logger": "workspace:^",
 		"nanoid": "^5.0.2",
 		"types": "workspace:^"

--- a/apps/consent-das/src/routers/clinicianInvites.ts
+++ b/apps/consent-das/src/routers/clinicianInvites.ts
@@ -20,7 +20,7 @@
 import { Router } from 'express';
 import withRequestValidation from 'express-request-validation';
 import { ConsentClinicianInviteRequest } from 'types/entities';
-import { ErrorName, ErrorResponse } from 'types/httpResponses';
+import { ConflictErrorResponse, ErrorName, ErrorResponse } from 'types/httpResponses';
 
 import { getClinicianInvite, getClinicianInvites } from '../service/search.js';
 import { createClinicianInvite } from '../service/create.js';
@@ -142,6 +142,9 @@ router.post(
 				}
 				case 'SYSTEM_ERROR': {
 					return res.status(500).json(ErrorResponse(SERVER_ERROR, invite.message));
+				}
+				case 'INVITE_EXISTS': {
+					return res.status(409).json(ConflictErrorResponse(invite.message));
 				}
 			}
 		} catch (error) {

--- a/apps/consent-das/src/routers/clinicianInvites.ts
+++ b/apps/consent-das/src/routers/clinicianInvites.ts
@@ -146,7 +146,7 @@ router.post(
 			}
 		} catch (error) {
 			logger.error('POST /invites', 'Unexpected error handling create invite request', error);
-			res.status(500).send(ErrorResponse(SERVER_ERROR, 'An unexpected error occurred.'));
+			return res.status(500).send(ErrorResponse(SERVER_ERROR, 'An unexpected error occurred.'));
 		}
 	}),
 );

--- a/apps/consent-das/src/routers/clinicianInvites.ts
+++ b/apps/consent-das/src/routers/clinicianInvites.ts
@@ -18,10 +18,15 @@
  */
 
 import { Router } from 'express';
+import withRequestValidation from 'express-request-validation';
+import { ConsentClinicianInviteRequest } from 'types/entities';
+import { ErrorName, ErrorResponse } from 'types/httpResponses';
 
 import { getClinicianInvite, getClinicianInvites } from '../service/search.js';
 import { createClinicianInvite } from '../service/create.js';
 import logger from '../logger.js';
+
+const { SERVER_ERROR } = ErrorName;
 
 // TODO: update JSDoc comments when custom error handling is implemented
 /**
@@ -111,72 +116,39 @@ router.get('/:inviteId', async (req, res) => {
  *       content:
  *         application/json:
  *           schema:
- *             type: object
- *             properties:
- *               clinicianFirstName:
- *                 type: string
- *                 required: true
- *               clinicianInstitutionalEmailAddress:
- *                 type: string
- *                 format: email
- *                 required: true
- *               clinicianLastName:
- *                 type: string
- *                 required: true
- *               clinicianTitleOrRole:
- *                 type: string
- *                 required: true
- *               consentGroup:
- *                 $ref: '#/components/schemas/ConsentGroup'
- *                 required: true
- *               consentToBeContacted:
- *                 type: boolean
- *                 required: true
- *               inviteAcceptedDate:
- *                 type: string
- *                 format: date
- *               inviteAccepted:
- *                 type: boolean
- *               clinicianInviteId:
- *                 type: string
+ *             $ref: '#/components/schemas/ClinicianInviteRequest'
  *     responses:
  *       201:
- *         description: The clinician invite was successfully created.
+ *         description: OK
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ClinicianInviteResponse'
+ *       400:
+ *         description: RequestValidationError - The request body was invalid.
+ *       409:
+ *         description: ConflictError - That request could not be made because it conflicts with data that already exists.
  *       500:
- *         description: Error creating clinician invite.
+ *         description: ServerError - An unexpected error occurred.
  */
-router.post('/', async (req, res) => {
-	logger.info('POST /clinician-invites');
-	const {
-		clinicianFirstName,
-		clinicianInstitutionalEmailAddress,
-		clinicianInviteId,
-		clinicianLastName,
-		clinicianTitleOrRole,
-		consentGroup,
-		consentToBeContacted,
-		inviteAcceptedDate,
-		inviteAccepted,
-	} = req.body;
-	// TODO: add validation
-	try {
-		const parsedInviteAcceptedDate = inviteAcceptedDate ? new Date(inviteAcceptedDate) : undefined;
-		const clinicianInvite = await createClinicianInvite({
-			clinicianFirstName,
-			clinicianInstitutionalEmailAddress,
-			clinicianInviteId,
-			clinicianLastName,
-			clinicianTitleOrRole,
-			consentGroup,
-			consentToBeContacted,
-			inviteAcceptedDate: parsedInviteAcceptedDate,
-			inviteAccepted,
-		});
-		res.status(201).send({ clinicianInvite });
-	} catch (error) {
-		logger.error(error);
-		res.status(500).send({ error: 'Error creating clinician invite' });
-	}
-});
+router.post(
+	'/',
+	withRequestValidation(ConsentClinicianInviteRequest, async (req, res) => {
+		try {
+			const invite = await createClinicianInvite(req.body);
+			switch (invite.status) {
+				case 'SUCCESS': {
+					return res.status(201).json(invite.data);
+				}
+				case 'SYSTEM_ERROR': {
+					return res.status(500).json(ErrorResponse(SERVER_ERROR, invite.message));
+				}
+			}
+		} catch (error) {
+			logger.error('POST /invites', 'Unexpected error handling create invite request', error);
+			res.status(500).send(ErrorResponse(SERVER_ERROR, 'An unexpected error occurred.'));
+		}
+	}),
+);
 
 export default router;

--- a/apps/consent-das/src/routers/swagger.ts
+++ b/apps/consent-das/src/routers/swagger.ts
@@ -26,6 +26,8 @@ import {
 	ConsentQuestionSchema as ConsentQuestion,
 	ConsentQuestionIdSchema as ConsentQuestionId,
 	LifecycleStateSchema as LifecycleState,
+	ConsentClinicianInviteRequestSchema as ClinicianInviteRequest,
+	ConsentClinicianInviteResponseSchema as ClinicianInviteResponse,
 } from 'types/entities';
 
 import packageJson from '../../package.json' assert { type: 'json' };
@@ -76,6 +78,8 @@ const options = swaggerJsdoc({
 				ConsentQuestion,
 				ConsentQuestionId,
 				LifecycleState,
+				ClinicianInviteRequest,
+				ClinicianInviteResponse,
 			},
 		},
 	},

--- a/apps/consent-das/src/service/create.ts
+++ b/apps/consent-das/src/service/create.ts
@@ -100,15 +100,13 @@ export const createClinicianInvite = async (
 		.create({
 			data: inviteRequest,
 		})
-		.then(
-			(invite) => success(invite),
-			(error) => {
-				logger.error(
-					'POST /invites',
-					'Unexpected error handling create invite request.',
-					error.message,
-				);
-				return failure('SYSTEM_ERROR', 'An unexpected error occurred.');
-			},
-		);
+		.then((invite) => success(invite))
+		.catch((error) => {
+			logger.error(
+				'POST /invites',
+				'Unexpected error handling create invite request.',
+				error.message,
+			);
+			return failure('SYSTEM_ERROR', 'An unexpected error occurred.');
+		});
 };

--- a/apps/consent-das/src/service/create.ts
+++ b/apps/consent-das/src/service/create.ts
@@ -107,7 +107,11 @@ export const createClinicianInvite = async (
 				if (error.code === 'P2002') {
 					// Prisma error code P2002 indicates "Unique constraint failed"
 					// See docs: https://www.prisma.io/docs/reference/api-reference/error-reference#p2002
-					logger.info('POST /invites', 'Unique constraint failed creating invite.', error.message);
+					logger.error(
+						'POST /invites',
+						`An invite already exists with that '${error.meta?.target ?? 'data'}'`,
+						error.message,
+					);
 					return failure(
 						'INVITE_EXISTS',
 						`An invite already exists with that '${error.meta?.target ?? 'data'}'`,

--- a/apps/consent-das/src/service/create.ts
+++ b/apps/consent-das/src/service/create.ts
@@ -107,15 +107,11 @@ export const createClinicianInvite = async (
 				if (error.code === 'P2002') {
 					// Prisma error code P2002 indicates "Unique constraint failed"
 					// See docs: https://www.prisma.io/docs/reference/api-reference/error-reference#p2002
-					logger.error(
-						'POST /invites',
-						`An invite already exists with that '${error.meta?.target ?? 'data'}'`,
-						error.message,
-					);
-					return failure(
-						'INVITE_EXISTS',
-						`An invite already exists with that '${error.meta?.target ?? 'data'}'`,
-					);
+					const errorMessage = `An invite already exists with that '${
+						error.meta?.target ?? 'data'
+					}'`;
+					logger.error('POST /invites', errorMessage, error.message);
+					return failure('INVITE_EXISTS', errorMessage);
 				}
 				logger.error('POST /invites', error.code, error.message);
 				return failure(

--- a/apps/consent-das/src/service/create.ts
+++ b/apps/consent-das/src/service/create.ts
@@ -1,3 +1,6 @@
+import { ConsentClinicianInviteRequest } from 'types/entities';
+import { Result, failure, success } from 'types/httpResponses';
+
 import prisma, {
 	Participant,
 	ConsentQuestion,
@@ -8,6 +11,9 @@ import prisma, {
 	ConsentQuestionId,
 	LifecycleState,
 } from '../prismaClient.js';
+import serviceLogger from '../logger.js';
+
+const logger = serviceLogger.forModule('PrismaClient');
 
 export const createParticipant = async ({
 	emailVerified,
@@ -81,40 +87,28 @@ export const createParticipantResponse = async ({
 	return result;
 };
 
-export const createClinicianInvite = async ({
-	clinicianFirstName,
-	clinicianInstitutionalEmailAddress,
-	clinicianInviteId,
-	clinicianLastName,
-	clinicianTitleOrRole,
-	consentGroup,
-	consentToBeContacted,
-	inviteAcceptedDate,
-	inviteAccepted,
-}: {
-	clinicianFirstName: string;
-	clinicianInstitutionalEmailAddress: string;
-	clinicianInviteId?: string;
-	clinicianLastName: string;
-	clinicianTitleOrRole: string;
-	consentGroup: ConsentGroup;
-	consentToBeContacted: boolean;
-	inviteAcceptedDate?: Date;
-	inviteAccepted?: boolean;
-}): Promise<ClinicianInvite> => {
-	// TODO: add error handling
-	const result = await prisma.clinicianInvite.create({
-		data: {
-			clinicianFirstName,
-			clinicianInstitutionalEmailAddress,
-			clinicianLastName,
-			clinicianTitleOrRole,
-			consentGroup,
-			consentToBeContacted,
-			id: clinicianInviteId,
-			inviteAcceptedDate,
-			inviteAccepted,
-		},
-	});
-	return result;
+type CreateInviteFailureStatus = 'SYSTEM_ERROR';
+/**
+ * Creates a ClinicianInvite entry in the Consent DB
+ * @param inviteRequest Clinician Invite data
+ * @returns ClinicianInvite object from Consent DB
+ */
+export const createClinicianInvite = async (
+	inviteRequest: ConsentClinicianInviteRequest,
+): Promise<Result<ClinicianInvite, CreateInviteFailureStatus>> => {
+	return await prisma.clinicianInvite
+		.create({
+			data: inviteRequest,
+		})
+		.then(
+			(invite) => success(invite),
+			(error) => {
+				logger.error(
+					'POST /invites',
+					'Unexpected error handling create invite request.',
+					error.message,
+				);
+				return failure('SYSTEM_ERROR', 'An unexpected error occurred.');
+			},
+		);
 };

--- a/apps/data-mapper/src/services/das/consent.ts
+++ b/apps/data-mapper/src/services/das/consent.ts
@@ -36,7 +36,7 @@ export const createInviteConsentData = async ({
 	const { consentDasUrl } = getAppConfig();
 	try {
 		const result = await axiosClient.post(urlJoin(consentDasUrl, 'clinician-invites'), {
-			clinicianInviteId: id,
+			id,
 			clinicianFirstName,
 			clinicianLastName,
 			clinicianInstitutionalEmailAddress,
@@ -45,7 +45,7 @@ export const createInviteConsentData = async ({
 			consentToBeContacted,
 		});
 		// converts all nulls to undefined
-		return ConsentClinicianInviteResponse.parse(result.data.clinicianInvite);
+		return ConsentClinicianInviteResponse.parse(result.data);
 	} catch (error) {
 		logger.error(error);
 		throw error; // TODO: remove and send custom error schema

--- a/apps/pi-das/src/service/create.ts
+++ b/apps/pi-das/src/service/create.ts
@@ -91,7 +91,11 @@ export const createClinicianInvite = async (
 				if (error.code === 'P2002') {
 					// Prisma error code P2002 indicates "Unique constraint failed"
 					// See docs: https://www.prisma.io/docs/reference/api-reference/error-reference#p2002
-					logger.info('POST /invites', 'Unique constraint failed creating invite.', error.message);
+					logger.error(
+						'POST /invites',
+						`An invite already exists with that '${error.meta?.target ?? 'data'}'`,
+						error.message,
+					);
 					return failure(
 						'INVITE_EXISTS',
 						`An invite already exists with that '${error.meta?.target ?? 'data'}'`,

--- a/apps/pi-das/src/service/create.ts
+++ b/apps/pi-das/src/service/create.ts
@@ -91,15 +91,11 @@ export const createClinicianInvite = async (
 				if (error.code === 'P2002') {
 					// Prisma error code P2002 indicates "Unique constraint failed"
 					// See docs: https://www.prisma.io/docs/reference/api-reference/error-reference#p2002
-					logger.error(
-						'POST /invites',
-						`An invite already exists with that '${error.meta?.target ?? 'data'}'`,
-						error.message,
-					);
-					return failure(
-						'INVITE_EXISTS',
-						`An invite already exists with that '${error.meta?.target ?? 'data'}'`,
-					);
+					const errorMessage = `An invite already exists with that '${
+						error.meta?.target ?? 'data'
+					}'`;
+					logger.error('POST /invites', errorMessage, error.message);
+					return failure('INVITE_EXISTS', errorMessage);
 				}
 				logger.error('POST /invites', error.code, error.message);
 				return failure(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       express-error-handler:
         specifier: workspace:^
         version: link:../../packages/express-error-handler
+      express-request-validation:
+        specifier: workspace:^
+        version: link:../../packages/express-request-validation
       logger:
         specifier: workspace:^
         version: link:../../packages/logger


### PR DESCRIPTION
## Description of Changes

Implemented complete error handling, validation, and logging for the `POST /invites` router and `createClinicianInvite` service in Consent DAS using `consent-api` and `pi-das` as an example.

### Consent DAS
- Added `express-request-validation` from shared packages to use `withRequestValidation` to validate the endpoint's request body
- Updated the endpoint's HTTP Responses to use the appropriate `ErrorResponse`
- Added a 400 RequestValidationError and 409 ConflictError to the endpoint responses, updated the JSDocs
- Updated the return type of the `createClinicianInvite` service to `Result` so it returns appropriate `Success` and `Failure` responses to the router
- Updated the Prisma create request so it returns a failure response if an error occurred
>**Note:** The endpoint request body validation was updated to use the Zod schema `ConsentClinicianInvite` so it now expects `id` as a request body field instead of `clinicianId`

### Special Instructions
Before running these changes, you will need to add `express-request-validation` to Consent DAS:
```
pnpm i
```

## PR Readiness Checklist

- [x] "Expected Outcome(s)" in ticket have been met
- [x] Ticket number included in PR title
- [x] Connected ticket to PR
- [x] Labels added to PR for service name (`consent-api`, `data-mapper`, etc...), type (`chore`, `documentation`, etc...), status (`draft`, `on-hold`, etc...) **if applicable**
- [x] Manual testing completed
- [x] Builds locally without errors or warnings
- [x] Tests are updated (if required) and passing
- [ ] PR feedback has been addressed **if applicable**
- [ ] New environment variables added to `.env.schema` files, `README.md`
- [ ] Added copyrights to new files
