### PR TITLE
✨ Add `DELETE /clinician-invites` route to PI DAS (#301)

### DIFF
--- a/apps/pi-das/src/routers/swagger.ts
+++ b/apps/pi-das/src/routers/swagger.ts
@@ -23,6 +23,7 @@ import swaggerJsdoc from 'swagger-jsdoc';
 import {
 	PIClinicianInviteRequestSchema as ClinicianInviteRequest,
 	PIClinicianInviteResponseSchema as ClinicianInviteResponse,
+	DeleteClinicianInviteRequestSchema as DeleteClinicianInviteRequest,
 } from 'types/entities';
 
 import packageJson from '../../package.json' assert { type: 'json' };
@@ -70,6 +71,7 @@ const options = swaggerJsdoc({
 			schemas: {
 				ClinicianInviteRequest,
 				ClinicianInviteResponse,
+				DeleteClinicianInviteRequest,
 			},
 		},
 	},

--- a/apps/pi-das/src/service/delete.ts
+++ b/apps/pi-das/src/service/delete.ts
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2023 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 import { DeleteClinicianInviteRequest } from 'types/entities';
 import { Result, failure, success } from 'types/httpResponses';
 

--- a/apps/pi-das/src/service/delete.ts
+++ b/apps/pi-das/src/service/delete.ts
@@ -1,0 +1,49 @@
+import { DeleteClinicianInviteRequest } from 'types/entities';
+import { Result, failure, success } from 'types/httpResponses';
+
+import prisma from '../prismaClient.js';
+import { PrismaClientKnownRequestError } from '../generated/client/runtime/library.js';
+import serviceLogger from '../logger.js';
+
+const logger = serviceLogger.forModule('PrismaClient');
+
+type DeleteInviteFailureStatus = 'SYSTEM_ERROR' | 'INVITE_DOES_NOT_EXIST';
+const DeleteInviteSuccess = { message: 'success' };
+/**
+ * Deletes a ClinicianInvite entry in the PI DB by invite ID
+ * @param id Clinician Invite ID
+ * @returns
+ */
+export const deleteClinicianInvite = async ({
+	id,
+}: DeleteClinicianInviteRequest): Promise<
+	Result<typeof DeleteInviteSuccess, DeleteInviteFailureStatus>
+> => {
+	return await prisma.clinicianInvite
+		.delete({
+			where: { id },
+		})
+		.then(() => success(DeleteInviteSuccess))
+		.catch((error) => {
+			if (error instanceof PrismaClientKnownRequestError) {
+				if (error.code === 'P2025') {
+					// Prisma error code P2025 indicates the record does not exist
+					// See docs: https://www.prisma.io/docs/reference/api-reference/error-reference#p2025
+					const errorMessage = `Invite with id '${id}' does not exist.`;
+					logger.error('DELETE /invites', errorMessage, error.message);
+					return failure('INVITE_DOES_NOT_EXIST', errorMessage);
+				}
+				logger.error('DELETE /invites', error.code, error.message);
+				return failure(
+					'SYSTEM_ERROR',
+					`An unexpected error occurred in the PrismaClient - ${error.code}`,
+				);
+			}
+			logger.error(
+				'DELETE /invites',
+				'Unexpected error handling delete invite request.',
+				error.message,
+			);
+			return failure('SYSTEM_ERROR', 'An unexpected error occurred.');
+		});
+};

--- a/packages/types/src/entities/ClinicianInvite/ClinicianInvite.ts
+++ b/packages/types/src/entities/ClinicianInvite/ClinicianInvite.ts
@@ -104,3 +104,12 @@ export const ClinicianInviteResponse = ClinicianInviteBase.refine((input) => {
 
 export type ClinicianInviteResponse = z.infer<typeof ClinicianInviteResponse>;
 export const ClinicianInviteResponseSchema: SchemaObject = generateSchema(ClinicianInviteResponse);
+
+export const DeleteClinicianInviteRequest = ClinicianInviteBase.pick({
+	id: true,
+});
+
+export type DeleteClinicianInviteRequest = z.infer<typeof DeleteClinicianInviteRequest>;
+export const DeleteClinicianInviteRequestSchema: SchemaObject = generateSchema(
+	DeleteClinicianInviteRequest,
+);

--- a/packages/types/src/httpResponses/NotFoundErrorResponse.ts
+++ b/packages/types/src/httpResponses/NotFoundErrorResponse.ts
@@ -17,20 +17,18 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-export enum ErrorName {
-	SERVER_ERROR = 'ServerError',
-	NOT_FOUND_ERROR = 'NotFoundError',
-	CONFLICT_ERROR = 'ConflictError',
-	REQUEST_VALIDATION_ERROR = 'RequestValidationError',
-	RECAPTCHA_ERROR = 'RecaptchaError',
-}
+import { ErrorName, ErrorResponse } from './ErrorResponse.js';
 
-export type ErrorResponse = {
-	error: ErrorName | 'NOT_IMPLEMENTED'; // TODO: remove once all routes are implemented
-	message: string;
-};
+const { NOT_FOUND_ERROR } = ErrorName;
 
-export const ErrorResponse = (error: ErrorName | 'NOT_IMPLEMENTED', message: string) => ({
-	error,
-	message,
+export type NotFound = ErrorResponse;
+
+/**
+ * Creates a NotFoundErrorResponse containing a message detailing the conflict and the fields causing it.
+ * @param customMessage
+ * @returns
+ */
+export const NotFoundErrorResponse = (customMessage?: string): NotFound => ({
+	error: NOT_FOUND_ERROR,
+	message: customMessage ?? 'The requested data could not be found.',
 });

--- a/packages/types/src/httpResponses/index.ts
+++ b/packages/types/src/httpResponses/index.ts
@@ -1,4 +1,5 @@
 export * from './ErrorResponse.js';
 export * from './ConflictErrorResponse.js';
+export * from './NotFoundErrorResponse.js';
 export * from './RequestValidationErrorResponse.js';
 export * from './Result.js';


### PR DESCRIPTION
## Description of Changes

Adds the `DELETE /clinician-invites` route to PI DAS which will be called by Data Mapper if an invite creation is unsuccessful in Consent DAS, in order to rollback an incomplete invite in PI DB.

### PI DAS
Created the endpoint which accepts the invite ID in the request body and calls `deleteClinicianInvite` to delete the invite from the PI DB if it already exists, otherwise returning an error response.
- Implemented the endpoint with error responses for `NotFoundError` and `ServerError`
- Documented endpoint in JSDocs, added component schema `DeleteClinicianInviteRequestSchema` to the Swagger router to use in the JSDocs
- Added the `deleteClinicianInvite` service with the `Result` return type returning success or failure statuses of `SYSTEM_ERROR` or `INVITE_DOES_NOT_EXIST`

### Types
- Added ErrorName `NOT_FOUND_ERROR` to support 404 responses and added a `NotFoundErrorResponse` type for convenience
- Added `DeleteClinicianInviteRequest` for the service parameters
- Added `DeleteClinicianInviteRequestSchema` for the endpoint JSDocs

## PR Readiness Checklist

- [x] "Expected Outcome(s)" in ticket have been met
- [x] Ticket number included in PR title
- [ ] Connected ticket to PR
- [x] Labels added to PR for service name (`consent-api`, `data-mapper`, etc...), type (`chore`, `documentation`, etc...), status (`draft`, `on-hold`, etc...) **if applicable**
- [x] Manual testing completed
- [x] Builds locally without errors or warnings
- [ ] Tests are updated (if required) and passing
- [ ] PR feedback has been addressed **if applicable**
- [ ] New environment variables added to `.env.schema` files, `README.md`
- [x] Added copyrights to new files
