### PR TITLE
🎨 #321: Add ServerErrorResponse type

### DIFF
--- a/apps/consent-api/src/routers/invites.ts
+++ b/apps/consent-api/src/routers/invites.ts
@@ -22,10 +22,9 @@ import withRequestValidation from 'express-request-validation';
 import { ClinicianInviteRequest, NanoId } from 'types/entities';
 import {
 	ConflictErrorResponse,
-	ErrorName,
-	ErrorResponse,
 	NotFoundErrorResponse,
 	RequestValidationErrorResponse,
+	ServerErrorResponse,
 } from 'types/httpResponses';
 import { z } from 'zod';
 
@@ -33,8 +32,6 @@ import { recaptchaMiddleware } from '../middleware/recaptcha.js';
 import { createInvite } from '../services/create.js';
 import logger from '../logger.js';
 import { getInvite } from '../services/search.js';
-
-const { SERVER_ERROR } = ErrorName;
 
 /**
  * @openapi
@@ -90,7 +87,7 @@ router.post(
 					return res.status(201).json(invite.data);
 				}
 				case 'SYSTEM_ERROR': {
-					return res.status(500).json(ErrorResponse(SERVER_ERROR, invite.message));
+					return res.status(500).json(ServerErrorResponse(invite.message));
 				}
 				case 'INVITE_EXISTS': {
 					return res.status(409).json(ConflictErrorResponse(invite.message));
@@ -98,7 +95,7 @@ router.post(
 			}
 		} catch (error) {
 			logger.error('POST /invites', `Unexpected error handling create invite request.`, error);
-			return res.status(500).send(ErrorResponse(SERVER_ERROR, 'An unexpected error occurred'));
+			return res.status(500).json(ServerErrorResponse());
 		}
 	}),
 );
@@ -152,12 +149,12 @@ router.get('/:inviteId', async (req, res) => {
 				return res.status(404).json(NotFoundErrorResponse(invite.message));
 			}
 			case 'SYSTEM_ERROR': {
-				return res.status(500).json(ErrorResponse(SERVER_ERROR, invite.message));
+				return res.status(500).json(ServerErrorResponse(invite.message));
 			}
 		}
 	} catch (error) {
 		logger.error('GET /invites/:inviteId', `Unexpected error handling get invite request.`, error);
-		return res.status(500).send(ErrorResponse(SERVER_ERROR, 'An unexpected error occurred'));
+		return res.status(500).json(ServerErrorResponse());
 	}
 });
 

--- a/apps/consent-api/src/routers/steps/informedConsent.ts
+++ b/apps/consent-api/src/routers/steps/informedConsent.ts
@@ -18,12 +18,10 @@
  */
 
 import { Router } from 'express';
-import { ErrorResponse, ErrorName } from 'types/httpResponses';
+import { ErrorResponse, ServerErrorResponse } from 'types/httpResponses';
 
 import logger from '../../logger.js';
 import { getInformedConsentResponses } from '../../services/search.js';
-
-const { SERVER_ERROR } = ErrorName;
 
 export const ROUTER_PATH = '/wizard/steps/informed-consent/';
 
@@ -100,12 +98,12 @@ router.get('/', async (req, res) => {
 				return res.status(200).json(participantResponses.data);
 			}
 			case 'SYSTEM_ERROR': {
-				return res.status(500).json(ErrorResponse(SERVER_ERROR, participantResponses.message));
+				return res.status(500).json(ServerErrorResponse(participantResponses.message));
 			}
 		}
 	} catch (error) {
 		logger.error(`GET ${ROUTER_PATH}`, 'Unexpected error handling get invite request', error);
-		return res.status(500).send(ErrorResponse(SERVER_ERROR, 'An unexpected error occurred.'));
+		return res.status(500).json(ServerErrorResponse());
 	}
 });
 

--- a/apps/consent-das/src/routers/clinicianInvites.ts
+++ b/apps/consent-das/src/routers/clinicianInvites.ts
@@ -22,19 +22,15 @@ import withRequestValidation from 'express-request-validation';
 import { ConsentClinicianInviteRequest, NanoId } from 'types/entities';
 import {
 	ConflictErrorResponse,
-	ErrorName,
-	ErrorResponse,
 	NotFoundErrorResponse,
 	RequestValidationErrorResponse,
+	ServerErrorResponse,
 } from 'types/httpResponses';
 
 import { getClinicianInviteById, getClinicianInvites } from '../services/search.js';
 import { createClinicianInvite } from '../services/create.js';
 import logger from '../logger.js';
 
-const { SERVER_ERROR } = ErrorName;
-
-// TODO: update JSDoc comments when custom error handling is implemented
 /**
  * @openapi
  * tags:
@@ -67,7 +63,7 @@ router.get('/', async (req, res) => {
 		res.status(200).send({ clinicianInvites });
 	} catch (error) {
 		logger.error(error);
-		res.status(500).send({ error: 'Error retrieving clinician invites' });
+		res.status(500).json(ServerErrorResponse('Error retrieving clinician invites'));
 	}
 });
 
@@ -125,7 +121,7 @@ router.get('/:inviteId', async (req, res) => {
 				return res.status(404).json(NotFoundErrorResponse(invite.message));
 			}
 			case 'SYSTEM_ERROR': {
-				return res.status(500).json(ErrorResponse(SERVER_ERROR, invite.message));
+				return res.status(500).json(ServerErrorResponse(invite.message));
 			}
 		}
 	} catch (error) {
@@ -134,7 +130,7 @@ router.get('/:inviteId', async (req, res) => {
 			'Unexpected error handling get invite request',
 			error,
 		);
-		return res.status(500).send(ErrorResponse(SERVER_ERROR, 'An unexpected error occurred.'));
+		return res.status(500).json(ServerErrorResponse());
 	}
 });
 
@@ -178,7 +174,7 @@ router.post(
 					return res.status(201).json(invite.data);
 				}
 				case 'SYSTEM_ERROR': {
-					return res.status(500).json(ErrorResponse(SERVER_ERROR, invite.message));
+					return res.status(500).json(ServerErrorResponse(invite.message));
 				}
 				case 'INVITE_EXISTS': {
 					return res.status(409).json(ConflictErrorResponse(invite.message));
@@ -186,7 +182,7 @@ router.post(
 			}
 		} catch (error) {
 			logger.error('DELETE /invites', 'Unexpected error handling delete invite request', error);
-			return res.status(500).send(ErrorResponse(SERVER_ERROR, 'An unexpected error occurred.'));
+			return res.status(500).json(ServerErrorResponse());
 		}
 	}),
 );

--- a/apps/consent-das/src/routers/consentQuestions.ts
+++ b/apps/consent-das/src/routers/consentQuestions.ts
@@ -19,14 +19,12 @@
 
 import { Router } from 'express';
 import { ConsentQuestionId, ConsentQuestionsRequest } from 'types/entities';
-import { ErrorName, ErrorResponse, RequestValidationErrorResponse } from 'types/httpResponses';
+import { RequestValidationErrorResponse, ServerErrorResponse } from 'types/httpResponses';
 
 import { updateConsentQuestionIsActive } from '../services/update.js';
 import { getConsentQuestion, getConsentQuestions } from '../services/search.js';
 import { createConsentQuestion } from '../services/create.js';
 import logger from '../logger.js';
-
-const { SERVER_ERROR } = ErrorName;
 
 /**
  * @openapi
@@ -85,12 +83,12 @@ router.get('/', async (req, res) => {
 				return res.status(200).json(consentQuestions.data);
 			}
 			case 'SYSTEM_ERROR': {
-				return res.status(500).json(ErrorResponse(SERVER_ERROR, consentQuestions.message));
+				return res.status(500).json(ServerErrorResponse(consentQuestions.message));
 			}
 		}
 	} catch (error) {
 		logger.error('GET /consent-questions', 'Unexpected error retrieving consent questions', error);
-		return res.status(500).send(ErrorResponse(SERVER_ERROR, 'An unexpected error occurred.'));
+		return res.status(500).json(ServerErrorResponse());
 	}
 });
 
@@ -127,7 +125,7 @@ router.get('/:consentQuestionId', async (req, res) => {
 		res.status(200).send({ question });
 	} catch (error) {
 		logger.error(error);
-		res.status(500).send({ error: 'Error retrieving consent questions' });
+		res.status(500).json(ServerErrorResponse('Error retrieving consent questions'));
 	}
 });
 
@@ -169,7 +167,7 @@ router.post('/', async (req, res) => {
 		res.status(201).send({ question });
 	} catch (error) {
 		logger.error(error);
-		res.status(500).send({ error: 'Error creating consent question' });
+		res.status(500).json(ServerErrorResponse('Error creating consent question'));
 	}
 });
 
@@ -219,7 +217,7 @@ router.patch('/:consentQuestionId', async (req, res) => {
 		res.status(200).send({ question });
 	} catch (error) {
 		logger.error(error);
-		res.status(500).send({ error: 'Error updating consent question active state' });
+		res.status(500).json(ServerErrorResponse('Error updating consent question active state'));
 	}
 });
 

--- a/apps/consent-das/src/routers/participantResponses.ts
+++ b/apps/consent-das/src/routers/participantResponses.ts
@@ -20,17 +20,14 @@
 import { Router } from 'express';
 import { ParticipantResponsesRequest } from 'types/entities';
 import {
-	ErrorName,
-	ErrorResponse,
 	NotFoundErrorResponse,
 	RequestValidationErrorResponse,
+	ServerErrorResponse,
 } from 'types/httpResponses';
 
 import { getParticipantResponses } from '../services/search.js';
 import { createParticipantResponse } from '../services/create.js';
 import logger from '../logger.js';
-
-const { SERVER_ERROR } = ErrorName;
 
 /**
  * @openapi
@@ -114,7 +111,7 @@ router.get('/:participantId/:consentQuestionId', async (req, res) => {
 				return res.status(404).json(NotFoundErrorResponse(participantResponses.message));
 			}
 			case 'SYSTEM_ERROR': {
-				return res.status(500).json(ErrorResponse(SERVER_ERROR, participantResponses.message));
+				return res.status(500).json(ServerErrorResponse(participantResponses.message));
 			}
 		}
 	} catch (error) {
@@ -123,7 +120,7 @@ router.get('/:participantId/:consentQuestionId', async (req, res) => {
 			'Unexpected error retrieving participant response',
 			error,
 		);
-		return res.status(500).send(ErrorResponse(SERVER_ERROR, 'An unexpected error occurred.'));
+		return res.status(500).json(ServerErrorResponse());
 	}
 });
 
@@ -170,7 +167,7 @@ router.post('/', async (req, res) => {
 		res.status(201).send({ participant_response });
 	} catch (error) {
 		logger.error(error);
-		res.status(500).send({ error: 'Error creating participant response' });
+		res.status(500).json(ServerErrorResponse('Error creating participant response'));
 	}
 });
 

--- a/apps/data-mapper/src/routers/invites.ts
+++ b/apps/data-mapper/src/routers/invites.ts
@@ -26,13 +26,14 @@ import {
 	ErrorResponse,
 	NotFoundErrorResponse,
 	RequestValidationErrorResponse,
+	ServerErrorResponse,
 } from 'types/httpResponses';
 
 import logger from '../logger.js';
 import { createInvite } from '../services/create.js';
 import { getInvite } from '../services/search.js';
 
-const { SERVER_ERROR, REQUEST_VALIDATION_ERROR } = ErrorName;
+const { REQUEST_VALIDATION_ERROR } = ErrorName;
 
 const router = Router();
 
@@ -95,12 +96,12 @@ router.get('/:inviteId', async (req, res) => {
 				return res.status(404).json(NotFoundErrorResponse(invite.message));
 			}
 			case 'SYSTEM_ERROR': {
-				return res.status(500).json(ErrorResponse(SERVER_ERROR, invite.message));
+				return res.status(500).json(ServerErrorResponse(invite.message));
 			}
 		}
 	} catch (error) {
 		logger.error('GET /invites/:inviteId', `Unexpected error handling get invite request.`, error);
-		return res.status(500).send(ErrorResponse(SERVER_ERROR, 'An unexpected error occurred'));
+		return res.status(500).json(ServerErrorResponse());
 	}
 });
 
@@ -145,12 +146,12 @@ router.post(
 					return res.status(409).json(ConflictErrorResponse(invite.message));
 				}
 				case 'SYSTEM_ERROR': {
-					return res.status(500).json(ErrorResponse(SERVER_ERROR, invite.message));
+					return res.status(500).json(ServerErrorResponse(invite.message));
 				}
 			}
 		} catch (error) {
 			logger.error('POST /invites', `Unexpected error handling create invite request.`, error);
-			return res.status(500).send(ErrorResponse(SERVER_ERROR, 'An unexpected error occurred'));
+			return res.status(500).json(ServerErrorResponse());
 		}
 	}),
 );

--- a/apps/data-mapper/src/routers/steps/informedConsent.ts
+++ b/apps/data-mapper/src/routers/steps/informedConsent.ts
@@ -23,13 +23,14 @@ import {
 	ErrorResponse,
 	NotFoundErrorResponse,
 	RequestValidationErrorResponse,
+	ServerErrorResponse,
 } from 'types/httpResponses';
 import { NanoId } from 'types/entities';
 
 import logger from '../../logger.js';
 import { getInformedConsentResponses } from '../../services/search.js';
 
-const { SERVER_ERROR, REQUEST_VALIDATION_ERROR } = ErrorName;
+const { REQUEST_VALIDATION_ERROR } = ErrorName;
 
 const ROUTER_PATH = '/wizard/steps/informed-consent';
 
@@ -95,7 +96,7 @@ router.get('/:participantId', async (req, res) => {
 				return res.status(404).json(NotFoundErrorResponse(participantResponses.message));
 			}
 			case 'SYSTEM_ERROR': {
-				return res.status(500).json(ErrorResponse(SERVER_ERROR, participantResponses.message));
+				return res.status(500).json(ServerErrorResponse(participantResponses.message));
 			}
 		}
 	} catch (error) {
@@ -104,7 +105,7 @@ router.get('/:participantId', async (req, res) => {
 			'Unexpected error handling get Informed Consent request',
 			error,
 		);
-		return res.status(500).send(ErrorResponse(SERVER_ERROR, 'An unexpected error occurred.'));
+		return res.status(500).json(ServerErrorResponse());
 	}
 });
 

--- a/apps/pi-das/src/routers/clinicianInvites.ts
+++ b/apps/pi-das/src/routers/clinicianInvites.ts
@@ -22,10 +22,9 @@ import withRequestValidation from 'express-request-validation';
 import { NanoId, PIClinicianInviteRequest } from 'types/entities';
 import {
 	ConflictErrorResponse,
-	ErrorName,
-	ErrorResponse,
 	NotFoundErrorResponse,
 	RequestValidationErrorResponse,
+	ServerErrorResponse,
 } from 'types/httpResponses';
 
 import { getClinicianInviteById, getClinicianInvites } from '../services/search.js';
@@ -33,9 +32,6 @@ import { createClinicianInvite } from '../services/create.js';
 import { deleteClinicianInvite } from '../services/delete.js';
 import logger from '../logger.js';
 
-const { SERVER_ERROR } = ErrorName;
-
-// TODO: update JSDoc comments when custom error handling is implemented
 /**
  * @openapi
  * tags:
@@ -67,7 +63,7 @@ router.get('/', async (req, res) => {
 		const invites = await getClinicianInvites();
 		res.status(200).send({ invites });
 	} catch (error) {
-		res.status(500).send({ error: 'Error retrieving clinician invites' });
+		res.status(500).json(ServerErrorResponse('Error retrieving clinician invites'));
 	}
 });
 
@@ -125,7 +121,7 @@ router.get('/:inviteId', async (req, res) => {
 				return res.status(404).json(NotFoundErrorResponse(invite.message));
 			}
 			case 'SYSTEM_ERROR': {
-				return res.status(500).json(ErrorResponse(SERVER_ERROR, invite.message));
+				return res.status(500).json(ServerErrorResponse(invite.message));
 			}
 		}
 	} catch (error) {
@@ -134,7 +130,7 @@ router.get('/:inviteId', async (req, res) => {
 			'Unexpected error handling get invite request',
 			error,
 		);
-		return res.status(500).send(ErrorResponse(SERVER_ERROR, 'An unexpected error occurred.'));
+		return res.status(500).json(ServerErrorResponse());
 	}
 });
 
@@ -181,12 +177,12 @@ router.post(
 					return res.status(409).json(ConflictErrorResponse(invite.message));
 				}
 				case 'SYSTEM_ERROR': {
-					return res.status(500).json(ErrorResponse(SERVER_ERROR, invite.message));
+					return res.status(500).json(ServerErrorResponse(invite.message));
 				}
 			}
 		} catch (error) {
 			logger.error('POST /invites', `Unexpected error handling create invite request.`, error);
-			return res.status(500).send(ErrorResponse(SERVER_ERROR, 'An unexpected error occurred'));
+			return res.status(500).json(ServerErrorResponse());
 		}
 	}),
 );
@@ -233,12 +229,12 @@ router.delete('/:inviteId', async (req, res) => {
 				return res.status(404).json(NotFoundErrorResponse(invite.message));
 			}
 			case 'SYSTEM_ERROR': {
-				return res.status(500).json(ErrorResponse(SERVER_ERROR, invite.message));
+				return res.status(500).json(ServerErrorResponse(invite.message));
 			}
 		}
 	} catch (error) {
 		logger.error('DELETE /invites', 'Unexpected error handling delete invite request', error);
-		return res.status(500).send(ErrorResponse(SERVER_ERROR, 'An unexpected error occurred.'));
+		return res.status(500).json(ServerErrorResponse());
 	}
 });
 

--- a/packages/types/src/httpResponses/NotFoundErrorResponse.ts
+++ b/packages/types/src/httpResponses/NotFoundErrorResponse.ts
@@ -22,7 +22,7 @@ import { ErrorName, ErrorResponse } from './ErrorResponse.js';
 const { NOT_FOUND_ERROR } = ErrorName;
 
 /**
- * Creates a NotFoundErrorResponse containing a message detailing the conflict and the fields causing it.
+ * Creates a NotFoundError Response containing a message detailing the conflict and the fields causing it.
  * @param customMessage
  * @returns
  */

--- a/packages/types/src/httpResponses/ServerErrorResponse.ts
+++ b/packages/types/src/httpResponses/ServerErrorResponse.ts
@@ -17,30 +17,16 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { ErrorRequestHandler } from 'express';
-import { ServerErrorResponse } from 'types/httpResponses';
-import { Logger } from 'logger';
+import { ErrorName, ErrorResponse } from './ErrorResponse.js';
+
+const { SERVER_ERROR } = ErrorName;
 
 /**
- * Create default response for unhandled errors to be json instead of html.
- *
- *
+ * Creates a ServerError Response containing a message detailing the problem.
+ * @param customMessage
  * @returns
  */
-const errorHandler =
-	(params: { logger?: Logger }): ErrorRequestHandler =>
-	(err, req, res, next) => {
-		const { logger } = params;
-
-		if (res.headersSent) {
-			return next(err);
-		}
-
-		logger?.error(`Unhandled error thrown from request`, req.url, err);
-
-		const message = (err.message && `${err.message}`) || 'An error occurred.';
-
-		return res.status(500).json(ServerErrorResponse(message));
-	};
-
-export default errorHandler;
+export const ServerErrorResponse = (customMessage?: string): ErrorResponse => ({
+	error: SERVER_ERROR,
+	message: customMessage ?? 'An unexpected error occurred.',
+});

--- a/packages/types/src/httpResponses/index.ts
+++ b/packages/types/src/httpResponses/index.ts
@@ -1,5 +1,6 @@
 export * from './ErrorResponse.js';
 export * from './ConflictErrorResponse.js';
 export * from './NotFoundErrorResponse.js';
+export * from './ServerErrorResponse.js';
 export * from './RequestValidationErrorResponse.js';
 export * from './Result.js';


### PR DESCRIPTION
## Description of Changes

Abstracts all `500 ServerError` responses we return in our routers to a `ServerErrorResponse` and updates all the routers to use it.

## PR Readiness Checklist

- [x] "Expected Outcome(s)" in ticket have been met
- [x] Ticket number included in PR title
- [x] Connected ticket to PR
- [x] Labels added to PR for service name (`consent-api`, `data-mapper`, etc...), type (`chore`, `documentation`, etc...), status (`draft`, `on-hold`, etc...) **if applicable**
- [x] Manual testing completed
- [x] Builds locally without errors or warnings
- [x] Tests are updated (if required) and passing
- [x] PR feedback has been addressed **if applicable**
- [x] New environment variables added to `.env.schema` files, `README.md`
- [x] Added copyrights to new files
