### PR TITLE
📝 Update router testing and shared types docs

### DIFF
--- a/apps/consent-api/src/routers/invites.ts
+++ b/apps/consent-api/src/routers/invites.ts
@@ -105,7 +105,7 @@ router.post(
 
 /**
  * @openapi
- * /invites:
+ * /invites/{inviteId}:
  *   get:
  *     tags:
  *       - Clinician Invites

--- a/apps/consent-api/tests/README.md
+++ b/apps/consent-api/tests/README.md
@@ -1,5 +1,11 @@
 # Unit Testing for Routers
 
+Unit testing the Consent API endpoints achieves several things:
+
+1. Verifies the appropriate service functions are called and the router is sending their returned data
+2. Verifies the response status codes
+3. Verifies the accepted error responses (request validation error, not found error, etc.)
+
 ## Making requests to endpoints
 
 We can make requests to our router endpoints using the `supertest` library, which lets us pass our exported `App` server to a `request` function and then make HTTP requests to App's routers. You can read more about it in the [docs](https://github.com/ladjs/supertest?tab=readme-ov-file#readme). Below is an example of how this can work:
@@ -12,6 +18,29 @@ const appConfig = getAppConfig();
 const response = await request(App(appConfig)).get('/wizard/steps/informed-consent');
 
 console.log(response.status); // 200
+```
+
+## Mocking the app config
+
+Since the unit tests are run in a separate environment, we mock the app config so we have control over the app config variables that are used in tests, specifically ones that use env vars. `mockEnv` defined in [`config.ts`](./config.ts) does two things:
+
+1. Stubs the `NODE_ENV` env var, because currently there are places in the code directly accessing `process.env.NODE_ENV` so we need to stub the env var directly. The remaining env vars should all be accessed via our app config.
+2. Mocks the `getAppConfig` return value so we can set custom values for the app config. This allows each test suite to have a different app config as needed.
+
+Since this involves stubbing env vars and mocking functions, it's important to [unstub all vars](https://vitest.dev/api/vi.html#vi-unstuballenvs) and [restore all mocks](https://vitest.dev/api/vi.html#vi-restoreallmocks) at the end of test suites, like so:
+
+```ts
+describe('Some test suite', () => {
+	// mock the app config/env
+	beforeAll(() => mockEnv());
+	// restore config and env after each suite
+	afterAll(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllEnvs();
+	});
+
+	// test suite
+});
 ```
 
 ## Mocking services

--- a/apps/consent-api/tests/config.ts
+++ b/apps/consent-api/tests/config.ts
@@ -23,7 +23,7 @@ import * as config from '../src/config.js';
 import { AppConfig } from '../src/config.js';
 
 export const mockEnv = (values?: Partial<AppConfig>) => {
-	// Need to set the NODE_ENV since there are currently places in teh code checking the process.env.NODE_ENV directly instead of relying on our config.
+	// Need to set the NODE_ENV since there are currently places in the code checking the process.env.NODE_ENV directly instead of relying on our config.
 	vi.stubEnv('NODE_ENV', values?.isProduction ? 'production' : 'development');
 
 	const defaultConfig: AppConfig = {

--- a/docs/shared-types.md
+++ b/docs/shared-types.md
@@ -5,67 +5,138 @@ This document describes how we use [Zod](https://zod.dev/) schemas to validate a
 ## Implementation
 
 ### Location
+
 All schemas are located in the `types` package under the [`types/src/entities`](../packages/types/src/entities/) directory. Common schemas (i.e. multiple complex schemas using the same base schema) are kept in directories by the base schema name (e.g. [`ClinicianInvite`](../packages/types/src/entities/ClinicianInvite/)).
 
-### Creating Schemas
-See the [docs](https://zod.dev/?id=basic-usage) for creating schemas and the different data types supported by Zod.
+### Create schemas
 
-### Extending Schemas
-Many of our schemas have common fields. For instance, because of the way we split up most of the logical data models by DAS, we end up with a schema for the Consent DAS Clinician Invite that is comprised of half of the fields from the whole Clinician Invite schema. To avoid duplicate code, we handle this by extending the base schema to create the Consent DAS Clinician Invite schema. Zod provides multiple methods for this:
-- [`extend()`](https://zod.dev/?id=extend) takes all the fields from an existing schema and allows you to add new fields (and overwrite existing fields too!)
-- [`pick()` and `omit()`](https://zod.dev/?id=pickomit) takes the specified fields, or takes all the fields omitting the specified fields from an existing schema
->**Note**: We prefer `pick` over `omit` because it is more readable to see exactly which fields are included, and it is generally safer. Say we add another field to the base schema but the subset does not change - using `pick` over `omit` in this case would prevent us from having to add another field to `omit` in the subset schema.
-
-For example, the `ConsentClinicianInviteRequest` looks like the following:
-
-```ts
-export const ConsentClinicianInviteRequest = ClinicianInviteBase.pick({
-	id: true,
-	clinicianFirstName: true,
-	clinicianLastName: true,
-	clinicianInstitutionalEmailAddress: true,
-	clinicianTitleOrRole: true,
-	consentGroup: true,
-	consentToBeContacted: true,
-});
-```
-
-Note that these are composable so you can chain as many of these as you want. **However, this does not apply when using [`refine()`](https://zod.dev/?id=refine) or [`transform()`](https://zod.dev/?id=transform)**.
+See the [Zod docs](https://zod.dev/?id=basic-usage) for creating schemas to validate data fields and the different data types supported by Zod.
 
 ### Preprocessing
-[`transform()`](https://zod.dev/?id=transform) allows you to perform a transform function on the input, which can be used on individual fields or entire schemas (e.g. converting lowercase letters to uppercase in postal code inputs).
 
-[`refine()`](https://zod.dev/?id=refine) allows you to perform a validation on the input which may be some complex logic that can't be captured with just the Zod data types, like checking for conditionally required fields on an API request body. This can also be used on individual fields or entire schemas.
-
-Both of these convert the schema to a `ZodEffects` type which "is a wrapper class that contains all logic pertaining to preprocessing, refinements, and transforms" so once a schema has `refine` or `transform` attached to it, it cannot be extended. If there is a schema that requires one of these, but it also must be extended, separate the `refine` or `transform` logic from it and make that the base schema. Then you can extend that base schema and add a `refine` or `transform` as needed on new schemas.
+Zod provides some methods that can be used on schemas after the general data type validation and before parsing.
 
 [`coerce()`](https://zod.dev/?id=coercion-for-primitives) can coerce primitive data types (e.g. converting a date string to a `Date` object).
 
+[`transform()`](https://zod.dev/?id=transform) allows you to perform a transform function on the input, which can be used on individual fields or entire schemas (e.g. converting lowercase letters to uppercase in postal code inputs).
+
+[`refine()`](https://zod.dev/?id=refine) allows you to perform custom validation on the input which may be some complex logic that can't be captured with just the Zod data types, like checking for conditionally required fields on an API request body. This can also be used on individual fields or entire schemas.
+
+These last two convert the schema to a `ZodEffects` type which "is a wrapper class that contains all logic pertaining to preprocessing, refinements, and transforms" so once a schema has `refine` or `transform` attached to it, it cannot be extended the same way a typical schema can with other ZodType methods. Because of this, we prioritize modular schemas and grouping together relevant fields, then [merging smaller schemas](#merging-schemas) to form whole entities. This way, if a particular set of fields requires a `transform` or `refine` we don't need to worry about being unable to extend and reuse other parts of that schema.
+
+### Merge schemas
+
+Many of our schemas have common fields. For instance, because of the way we split up most of the logical data models by DAS, we end up with a schema for the Consent DAS Clinician Invite that comprises half of the fields from the entire Clinician Invite entity. To avoid duplicate code, we handle this by splitting the larger schemas into smaller schemas, grouping together relevant fields. For example, for the `ClinicianInvite` schema we have the following subset schemas:
+
+```ts
+export const InviteClinicianFields = z.object({
+	clinicianFirstName: Name,
+	clinicianInstitutionalEmailAddress: z.string().email(),
+	clinicianLastName: Name,
+	clinicianTitleOrRole: z.string().trim().min(1),
+	consentGroup: ConsentGroup,
+	consentToBeContacted: z.literal(true),
+});
+
+export const InviteGuardianFields = z.object({
+	guardianEmailAddress: z.string().email().optional(),
+	guardianName: Name.optional(),
+	guardianPhoneNumber: PhoneNumber.optional(),
+	guardianRelationship: Name.optional(),
+});
+
+export const InviteParticipantFields = z.object({
+	participantEmailAddress: z.string().email(),
+	participantFirstName: Name,
+	participantLastName: Name,
+	participantPhoneNumber: PhoneNumber,
+	participantPreferredName: Name.optional(),
+});
+
+export const InviteEntity = z.object({
+	id: NanoId,
+	inviteSentDate: z.coerce.date(),
+	inviteAcceptedDate: z.coerce.date().optional(),
+	inviteAccepted: z.boolean().default(false),
+});
+```
+
+So the Clinician Invite request schema, which is the data required to create a clinician invite, would be the combination of all of these fields without the database generated fields, in other words, what we get from merging `InviteClinicianFields`, `InviteGuardianFields`, and `InviteParticipantFields`:
+
+```ts
+export const ClinicianInviteRequest =
+	InviteClinicianFields.merge(InviteGuardianFields).merge(InviteParticipantFields);
+```
+
+Now when we want to reuse portions of the larger schema, we can just merge some of the subset schemas. For example, the schema we use to validate the invite data coming from the Consent DAS looks like this:
+
+```ts
+export const ConsentClinicianInviteResponse = InviteEntity.merge(InviteClinicianFields).extend({
+	inviteAcceptedDate: z.coerce
+		.date()
+		.nullable()
+		.transform((input) => input ?? undefined),
+});
+```
+
+Here we merge the `InviteClinicianFields` with the set of fields generated by the database, `InviteEntity`. We are also extending the schema to overwrite the `inviteAcceptedDate`, which you can read more about in the section about [converting nulls to undefined](#converting-null-values-to-undefined).
+
+We use `merge` where it makes sense, but Zod provides other methods that _may_ be useful in certain instances.
+
+- [`extend()`](https://zod.dev/?id=extend) takes all the fields from an existing schema and allows you to add new fields (and overwrite existing fields too!)
+- [`pick()` and `omit()`](https://zod.dev/?id=pickomit) takes the specified fields, or takes all the fields omitting the specified fields from an existing schema.
+  > **Note**: We prefer `pick` over `omit` because it is more readable to see exactly which fields are included, and it is generally safer. Say we add another field to the base schema but the subset does not change - using `pick` over `omit` in this case would prevent us from having to add another field to `omit` in the subset schema. However in general, consider using `merge` over either method if you find that you're picking many fields, because that probably indicates those are fields that make sense being grouped together in a subset schema.
+
+These methods are all composable so you can chain together as many of them as you want. **However, this does not apply when using `refine()` or `transform()`**.
+
+### Refine schemas
+
+With the clinician invite request, we also have conditional logic involving the `InviteGuardianFields` and the `InviteClinicianFields`, specifically when the `consentGroup` is `GUARDIAN_CONSENT_OF_MINOR` or `GUARDIAN_CONSENT_OF_MINOR_INCLUDING_ASSENT`, all `InviteGuardianFields` are required to be defined, so each field is no longer `optional`. As a result, we `refine` the `ClinicianInviteRequest` schema which merges both of these schemas together:
+
+```ts
+export const ClinicianInviteRequest = InviteClinicianFields.merge(InviteGuardianFields)
+	.merge(InviteParticipantFields)
+	.refine(hasRequiredGuardianInformation, {
+		message: 'Guardian contact fields are required for that consentGroup',
+	});
+```
+
+As pointed out in the [Preprocessing](#preprocessing) section, we cannot merge more schemas to this after applying `refine` because it converts the schema to a `ZodEffects` type, so something like this wouldn't work:
+
+```ts
+export const ClinicianInviteRequest = InviteClinicianFields.merge(InviteGuardianFields)
+	.refine(hasRequiredGuardianInformation, {
+		message: 'Guardian contact fields are required for that consentGroup',
+	})
+	.merge(InviteParticipantFields);
+// Property 'merge' does not exist on type 'ZodEffects<...>'. ts(2339)
+```
+
+In other words, `refine` (or `transform`) should be the last method being performed on a schema. For example, the entire `ClinicianInvite` schema combines the request data with the database generated fields, so the `ClinicianInviteRequest` is chained on last:
+
+```ts
+export const ClinicianInvite = InviteEntity.and(ClinicianInviteRequest);
+```
+
+Also note that we're using [`and`](https://zod.dev/?id=and) here instead of `merge`, to represent the type intersection: `ClinicianInvite = InviteEntity & ClinicianInviteRequest`, whereas `merge` is equivalent to extending an interface in TS. You can read more about it in the [docs](https://zod.dev/?id=intersections).
 
 ## Usage
 
-Zod's [`parse()`](https://zod.dev/?id=parse) method simultaneously validates the data and can also coerce any data types or transform fields, as outlined in the Zod schema.
+### Validation and parsing
 
->**Note**: Zod's `parse` does **not** throw an error if it encounters unrecognized fields, it simply parses those out of the output. To disallow unknown fields, see [`strict()`](https://zod.dev/?id=strict).
+Zod's [`parse()`](https://zod.dev/?id=parse) method simultaneously validates the data and can also coerce any data types or transform fields, as outlined in the Zod schema. Similarly, [`safeParse()`](https://zod.dev/?id=safeparse) can be used to parse the data, but rather than throwing an error if the validation was unsuccesful, the `safeParse` method "returns an object containing either the successfully parsed data or a ZodError instance containing detailed information about the validation problems".
+
+> **Note**: Zod's validation does **not** fail if it encounters unrecognized fields, it simply parses those out of the output. To disallow unknown fields, see [`strict()`](https://zod.dev/?id=strict).
 
 ### Converting `null` values to `undefined`
+
 Optional fields will be `undefined` if a value is not provided. However, in the DB, `undefined` values will be stored as `null`, so any data from a DAS response will need to go through a conversion step before being returned to the Data Mapper.
 
 This is done by overwriting the base fields from [`optional()`](https://zod.dev/?id=optional) (which accepts either the specified data type or `undefined`) to [`nullable()`](https://zod.dev/?id=nullable) (which accepts the specified data type or `null`). This ensures the schema will accept any `null` values as opposed to throwing a validation error. Then by adding a transform on any `nullable()` field, we can have Zod’s `parse()` convert it to `undefined` if the value is `null`. We do this in the `ConsentClinicianInviteResponse` and `PIClinicianInviteResponse` schemas, which are the response types for the Consent and PI DAS API calls to create a clinician invite. As an example, the `ConsentClinicianInviteResponse` schema looks like the following:
 
 ```ts
-export const ConsentClinicianInviteResponse = ClinicianInviteBase.pick({
-	id: true,
-	inviteSentDate: true,
-	inviteAcceptedDate: true, // inviteAcceptedDate is z.coerce.date().optional() in the ClinicianInviteBase schema
-	inviteAccepted: true,
-	clinicianFirstName: true,
-	clinicianLastName: true,
-	clinicianInstitutionalEmailAddress: true,
-	clinicianTitleOrRole: true,
-	consentGroup: true,
-	consentToBeContacted: true,
-}).extend({
+// inviteAcceptedDate is z.coerce.date().optional() in the InviteEntity schema
+export const ConsentClinicianInviteResponse = InviteEntity.merge(InviteClinicianFields).extend({
 	inviteAcceptedDate: z.coerce
 		.date()
 		.nullable() // we overwrite it to be nullable() instead of optional()
@@ -73,7 +144,7 @@ export const ConsentClinicianInviteResponse = ClinicianInviteBase.pick({
 });
 ```
 
-The expected behaviour is described in the test cases below (we use `safeParse()` instead of `parse()` in the test cases so no errors are actually thrown, see the [docs](https://zod.dev/?id=safeparse) for more details):
+The expected behaviour is described in the test cases below:
 
 ```ts
 describe('ConsentClinicianInviteResponse', () => {
@@ -111,5 +182,55 @@ describe('ConsentClinicianInviteResponse', () => {
 			new Date('10-31-2023').getTime(),
 		); // untouched since it was not null
 	});
+});
+```
+
+### Swagger Schemas
+
+We use the [`zod-openapi`](https://github.com/anatine/zod-plugins/tree/main/packages/zod-openapi) library to dynamically generate Swagger schemas from our Zod schemas, which can be imported into our `swagger.ts` routers and used as component schemas in our Swagger JSDocs. First, export the generated schema like so:
+
+```ts
+export const ClinicianInviteResponseSchema = generateSchema(ClinicianInviteResponse);
+```
+
+Now import it into the Swagger router:
+
+```ts
+import { ClinicianInviteResponseSchema as ClinicianInviteResponse } from 'types/entities';
+
+const options = swaggerJsdoc({
+	definition: {
+		...
+		components: {
+			schemas: {
+				ClinicianInviteResponse,
+			},
+		},
+	},
+	...
+});
+
+const router = Router();
+router.use('/', serve, setup(options));
+```
+
+And now the schema can be referenced in Swagger JSDocs:
+
+```ts
+/**
+ * @openapi
+ * /invites/{inviteId}:
+ *   get:
+ *     ...
+ *     responses:
+ *       200:
+ *         description: OK
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ClinicianInviteResponse'
+ */
+router.get('/:inviteId', async (req, res) => {
+	...
 });
 ```

--- a/packages/types/src/entities/ClinicianInvite/PIClinicianInvite.ts
+++ b/packages/types/src/entities/ClinicianInvite/PIClinicianInvite.ts
@@ -23,9 +23,9 @@ import { SchemaObject } from 'openapi3-ts/oas31';
 
 import { Name } from '../Name.js';
 import { PhoneNumber } from '../PhoneNumber.js';
+import { NanoId } from '../NanoId.js';
 
 import { InviteGuardianFields, InviteParticipantFields } from './ClinicianInvite.js';
-import { NanoId } from '../NanoId.js';
 
 export const PIClinicianInviteRequest = InviteParticipantFields.merge(InviteGuardianFields);
 

--- a/packages/types/src/entities/ParticipantIdentification.ts
+++ b/packages/types/src/entities/ParticipantIdentification.ts
@@ -27,6 +27,7 @@ import { Name } from './Name.js';
 import { OhipNumber } from './OhipNumber.js';
 import { NanoId } from './NanoId.js';
 import { LifecycleState } from './LifecycleState.js';
+
 import { InviteGuardianFields } from './index.js';
 
 export const hasRequiredGuardianInformation = (


### PR DESCRIPTION
## Description of Changes

Updated the shared types docs after the refactoring of the `ClinicianInvite` schemas. Also updated the README in the routers unit test directory to include how we mock the app config and environment vars. Caught a few formatting bugs while looking through these files too and fixed them!

## PR Readiness Checklist

- [ ] "Expected Outcome(s)" in ticket have been met
- [ ] Ticket number included in PR title
- [ ] Connected ticket to PR
- [x] Labels added to PR for service name (`consent-api`, `data-mapper`, etc...), type (`chore`, `documentation`, etc...), status (`draft`, `on-hold`, etc...) **if applicable**
- [x] Manual testing completed
- [x] Builds locally without errors or warnings
- [ ] Tests are updated (if required) and passing
- [ ] PR feedback has been addressed **if applicable**
- [ ] New environment variables added to `.env.schema` files, `README.md`
- [ ] Added copyrights to new files
