### PR TITLE
🔨📝 pins node version to 18.18.2 to mitigate ts-node issue

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -4,7 +4,7 @@ kind: Pod
 spec:
   containers:
   - name: node
-    image: node:18.19.0
+    image: node:18.18.2
     tty: true
     env:
     - name: DOCKER_HOST

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ To run the setup locally, ensure you have provided the **required** environment 
 - Install pnpm: `brew install pnpm`
 - Install dependencies: `pnpm install`
 
-> **Note:** This repo is using the LTS version of node (currently v18)
+> **Note:** Node v20.x is the latest LTS version, but there is an incompatibility issue with ts-node https://github.com/TypeStrong/ts-node/issues/1997. This repo enforces using Node v18.18.2 to work with ts-node and ECMAScript Modules (ESM).
 
 ### VS Code Configuration
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
 	"version": "1.0.0",
 	"description": "",
 	"main": "index.js",
+	"engines": {
+		"node": "18.18.2"
+	  },
 	"scripts": {
 		"build": "pnpm -r run build",
 		"consent-ui-dev": "pnpm --filter consent-ui run dev",


### PR DESCRIPTION
## Description of Changes

Pins Node version in main package.json file to `18.18.2`. This will override the `engines` setting in the apps' and packages' package.json files

This fixes an issue with `ts-node` that was introduced in Node `18.19.0`.
Similar issue to https://github.com/OHCRN/platform/issues/350

- updates Jenkinsfile to match node versions
- updates note in main README

## PR Readiness Checklist

- [ ] "Expected Outcome(s)" in ticket have been met
- [ ] Ticket number included in PR title
- [ ] Connected ticket to PR
- [ ] Labels added to PR for service name (`consent-api`, `data-mapper`, etc...), type (`chore`, `documentation`, etc...), status (`draft`, `on-hold`, etc...) **if applicable**
- [ ] Manual testing completed
- [ ] Builds locally without errors or warnings
- [ ] Tests are updated (if required) and passing
- [ ] PR feedback has been addressed **if applicable**
- [ ] New environment variables added to `.env.schema` files, `README.md`
- [ ] Added copyrights to new files
