### PR TITLE
💄#349: Add consentui ReviewInfoCard component

### DIFF
--- a/apps/consent-ui/src/components/common/ReviewInfoCard/ReviewInfoCard.module.scss
+++ b/apps/consent-ui/src/components/common/ReviewInfoCard/ReviewInfoCard.module.scss
@@ -11,8 +11,16 @@
 	gap: 1.5rem;
 	padding: 0.5rem;
 
+	@media (min-width: theme('screens.sm')) {
+		padding: 0.5rem 0.75rem;
+		gap: 1rem;
+	}
+
 	h2 {
 		font-size: theme('fontSize.base');
+		@media (min-width: theme('screens.sm')) {
+			font-size: theme('fontSize.xl');
+		}
 	}
 }
 
@@ -35,6 +43,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	text-align: center;
 
 	margin: 0;
 	font-size: theme('fontSize.sm');
@@ -49,10 +58,52 @@
 
 .subtitle {
 	font-size: theme('fontSize.sm');
+	@media (min-width: theme('screens.sm')) {
+		font-size: theme('fontSize.base');
+	}
+	@media (min-width: theme('screens.md')) {
+		font-size: theme('fontSize.lg');
+	}
 }
 
 .fields {
-	display: flex;
-	flex-direction: column;
+	display: grid;
 	gap: inherit;
+	
+	grid-template-columns: 1fr;
+	@media (min-width: theme('screens.sm')) {
+		grid-template-columns: 1fr 1fr;
+		padding: 1.5rem;
+	}
+	@media (min-width: theme('screens.md')) {
+		padding: 0.5rem 0;
+		gap: 2rem;
+	}
+
+	.field {
+		display: flex;
+		flex-direction: column;
+
+		@media (min-width: theme('screens.sm')) {
+			flex-direction: row;
+			gap: 1rem;
+		}
+
+		.fieldLabel {
+			flex: 1;
+			font-size: theme('fontSize.base');
+		}
+
+		.fieldValue {
+			flex: 1;
+
+			font-size: theme('fontSize.base');
+			@media (min-width: theme('screens.sm')) {
+				font-size: theme('fontSize.lg');
+			}
+			@media (min-width: theme('screens.md')) {
+				font-size: theme('fontSize.base');
+			}
+		}
+	}
 }

--- a/apps/consent-ui/src/components/common/ReviewInfoCard/ReviewInfoCard.module.scss
+++ b/apps/consent-ui/src/components/common/ReviewInfoCard/ReviewInfoCard.module.scss
@@ -43,7 +43,9 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+
 	text-align: center;
+	text-decoration: none;
 
 	margin: 0;
 	font-size: theme('fontSize.sm');

--- a/apps/consent-ui/src/components/common/ReviewInfoCard/ReviewInfoCard.module.scss
+++ b/apps/consent-ui/src/components/common/ReviewInfoCard/ReviewInfoCard.module.scss
@@ -1,0 +1,58 @@
+.reviewInfoCard {
+	background-color: theme('colors.primary.100');
+
+	border: 1px solid;
+	border-color: theme('colors.primary.600');
+	color: theme('colors.grayscale.800');
+
+	height: fit-content;
+	display: flex;
+	flex-direction: column;
+	gap: 1.5rem;
+	padding: 0.5rem;
+
+	h2 {
+		font-size: theme('fontSize.base');
+	}
+}
+
+.header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 1rem;
+}
+
+.redirectButton {
+	width: 74px;
+	height: 30px;
+	border-radius: 25px;
+	border: 2px solid;
+	gap: 10px;
+
+	background-color: theme('colors.grayscale.800');
+	color: theme('colors.grayscale.100');
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
+	margin: 0;
+	font-size: theme('fontSize.sm');
+	font-weight: 700;
+	line-height: 26px;
+}
+
+.required {
+	color: theme('colors.error.500');
+	margin-left: 0.5em;
+}
+
+.subtitle {
+	font-size: theme('fontSize.sm');
+}
+
+.fields {
+	display: flex;
+	flex-direction: column;
+	gap: inherit;
+}

--- a/apps/consent-ui/src/components/common/ReviewInfoCard/ReviewInfoCard.module.scss
+++ b/apps/consent-ui/src/components/common/ReviewInfoCard/ReviewInfoCard.module.scss
@@ -71,7 +71,7 @@
 .fields {
 	display: grid;
 	gap: inherit;
-	
+
 	grid-template-columns: 1fr;
 	@media (min-width: theme('screens.sm')) {
 		grid-template-columns: 1fr 1fr;

--- a/apps/consent-ui/src/components/common/ReviewInfoCard/index.tsx
+++ b/apps/consent-ui/src/components/common/ReviewInfoCard/index.tsx
@@ -19,17 +19,24 @@
 
 import clsx from 'clsx';
 
+import type { ValidLanguage } from 'src/i18n';
+
+import LocalizedLink from '../Link/LocalizedLink';
+import type { RouteName } from '../Link/types';
+
 import styles from './ReviewInfoCard.module.scss';
 
 const ReviewInfoCard = ({
-	// layout = 'column',
+	name,
+	linkLang,
 	className,
 	fields,
 	title,
 	subtitle,
 	required = false,
 }: {
-	// layout?: 'column' | 'row';
+	name: RouteName;
+	linkLang: ValidLanguage;
 	className?: string;
 	fields?: {
 		label: string;
@@ -43,20 +50,24 @@ const ReviewInfoCard = ({
 		<div className={clsx(styles.reviewInfoCard, className)}>
 			<div className={clsx(styles.header)}>
 				<h2>{title}</h2>
-				<div className={styles.redirectButton}>Edit</div>
+				<LocalizedLink className={styles.redirectButton} name={name} linkLang={linkLang}>
+					Edit
+				</LocalizedLink>
 			</div>
 			<div className={clsx(styles.subtitle)}>
 				{subtitle}
 				{required && <span className={styles.required}>*</span>}
 			</div>
-			<div className={styles.fields}>
-				{fields?.map((field, i) => (
-					<div key={i} className={styles.field}>
-						<h2 className={styles.fieldLabel}>{field.label}</h2>
-						<div className={styles.fieldValue}>{field.value}</div>
-					</div>
-				))}
-			</div>
+			{fields && (
+				<div className={styles.fields}>
+					{fields.map((field) => (
+						<div key={`${field.label}-${field.value}`} className={styles.field}>
+							<h2 className={styles.fieldLabel}>{field.label}</h2>
+							<div className={styles.fieldValue}>{field.value}</div>
+						</div>
+					))}
+				</div>
+			)}
 		</div>
 	);
 };

--- a/apps/consent-ui/src/components/common/ReviewInfoCard/index.tsx
+++ b/apps/consent-ui/src/components/common/ReviewInfoCard/index.tsx
@@ -51,9 +51,9 @@ const ReviewInfoCard = ({
 			</div>
 			<div className={styles.fields}>
 				{fields?.map((field, i) => (
-					<div key={i}>
-						<h2>{field.label}</h2>
-						<div>{field.value}</div>
+					<div key={i} className={styles.field}>
+						<h2 className={styles.fieldLabel}>{field.label}</h2>
+						<div className={styles.fieldValue}>{field.value}</div>
 					</div>
 				))}
 			</div>

--- a/apps/consent-ui/src/components/common/ReviewInfoCard/index.tsx
+++ b/apps/consent-ui/src/components/common/ReviewInfoCard/index.tsx
@@ -19,7 +19,7 @@
 
 import clsx from 'clsx';
 
-import type { ValidLanguage } from 'src/i18n';
+import type { ValidLanguage } from 'src/i18n/types';
 
 import LocalizedLink from '../Link/LocalizedLink';
 import type { RouteName } from '../Link/types';
@@ -32,7 +32,7 @@ const ReviewInfoCard = ({
 	className,
 	fields,
 	title,
-	subtitle,
+	children, // subtitle
 	required = false,
 }: {
 	name: RouteName;
@@ -43,7 +43,7 @@ const ReviewInfoCard = ({
 		value: string;
 	}[];
 	title: string;
-	subtitle: string;
+	children: React.ReactNode;
 	required?: boolean;
 }) => {
 	return (
@@ -55,7 +55,7 @@ const ReviewInfoCard = ({
 				</LocalizedLink>
 			</div>
 			<div className={clsx(styles.subtitle)}>
-				{subtitle}
+				{children}
 				{required && <span className={styles.required}>*</span>}
 			</div>
 			{fields && (

--- a/apps/consent-ui/src/components/common/ReviewInfoCard/index.tsx
+++ b/apps/consent-ui/src/components/common/ReviewInfoCard/index.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import clsx from 'clsx';
+
+import styles from './ReviewInfoCard.module.scss';
+
+const ReviewInfoCard = ({
+	// layout = 'column',
+	className,
+	fields,
+	title,
+	subtitle,
+	required = false,
+}: {
+	// layout?: 'column' | 'row';
+	className?: string;
+	fields?: {
+		label: string;
+		value: string;
+	}[];
+	title: string;
+	subtitle: string;
+	required?: boolean;
+}) => {
+	return (
+		<div className={clsx(styles.reviewInfoCard, className)}>
+			<div className={clsx(styles.header)}>
+				<h2>{title}</h2>
+				<div className={styles.redirectButton}>Edit</div>
+			</div>
+			<div className={clsx(styles.subtitle)}>
+				{subtitle}
+				{required && <span className={styles.required}>*</span>}
+			</div>
+			<div className={styles.fields}>
+				{fields?.map((field, i) => (
+					<div key={i}>
+						<h2>{field.label}</h2>
+						<div>{field.value}</div>
+					</div>
+				))}
+			</div>
+		</div>
+	);
+};
+
+export default ReviewInfoCard;

--- a/apps/consent-ui/src/components/views/ConsentWizard/index.tsx
+++ b/apps/consent-ui/src/components/views/ConsentWizard/index.tsx
@@ -24,7 +24,6 @@ import Card from 'src/components/common/Card';
 import ProgressHeader from 'src/components/common/ProgressHeader';
 import PaddedContainer from 'src/components/common/PaddedContainer';
 import BackToDashboard from 'src/components/common/BackToDashboard';
-import ReviewInfoCard from 'src/components/common/ReviewInfoCard';
 
 import styles from './ConsentWizard.module.scss';
 
@@ -82,49 +81,7 @@ const ConsentWizard = async ({
 						{currentStep === CONSENT_RELEASE_DATA && <></>}
 						{currentStep === CONSENT_RESEARCH_PARTICIPATION && <></>}
 						{currentStep === CONSENT_RECONTACT && <></>}
-						{currentStep === CONSENT_REVIEW_SIGN && (
-							<>
-								<ReviewInfoCard
-									name="consent-1"
-									linkLang="en"
-									title="Release of Health Data"
-									required={true}
-									fields={[
-										{
-											label: 'Preferred Name',
-											value: 'Lala',
-										},
-										{
-											label: 'Name on OHIP',
-											value: 'Paula Smith',
-										},
-										{
-											label: 'Gender Identity',
-											value: 'Prefer not to disclose',
-										},
-										{
-											label: 'OHIP',
-											value: '1234 567 890 AA',
-										},
-										{
-											label: 'Date of Birth',
-											value: '01/09/1991',
-										},
-										{
-											label: 'Sex Assigned at Birth',
-											value: 'Female',
-										},
-										{
-											label: 'Ancestry',
-											value: 'Hispanic/Latinx',
-										},
-									]}
-								>
-									I agree to the release and update of clinical and genetic data obtained from
-									applicable institutions and provided by the patient, to be stored within OHCRN.
-								</ReviewInfoCard>
-							</>
-						)}
+						{currentStep === CONSENT_REVIEW_SIGN && <></>}
 					</div>
 				</Card>
 			</div>

--- a/apps/consent-ui/src/components/views/ConsentWizard/index.tsx
+++ b/apps/consent-ui/src/components/views/ConsentWizard/index.tsx
@@ -24,6 +24,7 @@ import Card from 'src/components/common/Card';
 import ProgressHeader from 'src/components/common/ProgressHeader';
 import PaddedContainer from 'src/components/common/PaddedContainer';
 import BackToDashboard from 'src/components/common/BackToDashboard';
+import ReviewInfoCard from 'src/components/common/ReviewInfoCard';
 
 import styles from './ConsentWizard.module.scss';
 
@@ -81,7 +82,49 @@ const ConsentWizard = async ({
 						{currentStep === CONSENT_RELEASE_DATA && <></>}
 						{currentStep === CONSENT_RESEARCH_PARTICIPATION && <></>}
 						{currentStep === CONSENT_RECONTACT && <></>}
-						{currentStep === CONSENT_REVIEW_SIGN && <></>}
+						{currentStep === CONSENT_REVIEW_SIGN && (
+							<>
+								<ReviewInfoCard
+									name="consent-1"
+									linkLang="en"
+									title="Release of Health Data"
+									required={true}
+									fields={[
+										{
+											label: 'Preferred Name',
+											value: 'Lala',
+										},
+										{
+											label: 'Name on OHIP',
+											value: 'Paula Smith',
+										},
+										{
+											label: 'Gender Identity',
+											value: 'Prefer not to disclose',
+										},
+										{
+											label: 'OHIP',
+											value: '1234 567 890 AA',
+										},
+										{
+											label: 'Date of Birth',
+											value: '01/09/1991',
+										},
+										{
+											label: 'Sex Assigned at Birth',
+											value: 'Female',
+										},
+										{
+											label: 'Ancestry',
+											value: 'Hispanic/Latinx',
+										},
+									]}
+								>
+									I agree to the release and update of clinical and genetic data obtained from
+									applicable institutions and provided by the patient, to be stored within OHCRN.
+								</ReviewInfoCard>
+							</>
+						)}
 					</div>
 				</Card>
 			</div>


### PR DESCRIPTION
## Description of Changes

Adds the ReviewInfoCard component - the big green box on step 5 of the consent UI. This box displays the user's information, with capability to go back to a specific step edit their info.

## PR Readiness Checklist

- [x] "Expected Outcome(s)" in ticket have been met
- [x] Ticket number included in PR title
- [x] Connected ticket to PR
- [x] Labels added to PR for service name (`consent-api`, `data-mapper`, etc...), type (`chore`, `documentation`, etc...), status (`draft`, `on-hold`, etc...) **if applicable**
- [x] Manual testing completed
- [x] Builds locally without errors or warnings
- [x] Tests are updated (if required) and passing
- [ ] PR feedback has been addressed **if applicable**
- [x] New environment variables added to `.env.schema` files, `README.md`
- [x] Added copyrights to new files
