### PR TITLE
🐛#396: Fix Help button height in Safari

### DIFF
--- a/apps/consent-ui/src/components/common/Header/HelpButton.module.scss
+++ b/apps/consent-ui/src/components/common/Header/HelpButton.module.scss
@@ -4,6 +4,5 @@
 	padding-right: 0.9rem !important;
 	svg {
 		width: 1.4rem !important;
-		height: fit-content;
 	}
 }

--- a/apps/consent-ui/src/components/common/Header/HelpButton.module.scss
+++ b/apps/consent-ui/src/components/common/Header/HelpButton.module.scss
@@ -4,6 +4,6 @@
 	padding-right: 0.9rem !important;
 	svg {
 		width: 1.4rem !important;
-		height: fit-content !important;
+		height: fit-content;
 	}
 }


### PR DESCRIPTION
## Description of Changes

Fixes header button height in Safari, see ticket for the screenshot

## PR Readiness Checklist

- [x] "Expected Outcome(s)" in ticket have been met
- [x] Ticket number included in PR title
- [x] Connected ticket to PR
- [x] Labels added to PR for service name (`consent-api`, `data-mapper`, etc...), type (`chore`, `documentation`, etc...), status (`draft`, `on-hold`, etc...) **if applicable**
- [x] Manual testing completed
- [ x Builds locally without errors or warnings
- [x] Tests are updated (if required) and passing
- [ ] PR feedback has been addressed **if applicable**
- [x] New environment variables added to `.env.schema` files, `README.md`
- [x] Added copyrights to new files
