### PR TITLE
✏️  change __blank to _blank

### DIFF
--- a/apps/consent-ui/src/components/views/ConsentWizard/InformedConsent/index.tsx
+++ b/apps/consent-ui/src/components/views/ConsentWizard/InformedConsent/index.tsx
@@ -41,7 +41,7 @@ const InformedConsent = ({ currentLang }: { currentLang: ValidLanguage }) => {
 			<h2 className={styles.title}>{pageDict.title}</h2>
 			<p className={styles.description}>
 				{pageDict.description1}
-				<Link href={studyConsentPdfUrl} prefetch={false} target="__blank">
+				<Link href={studyConsentPdfUrl} prefetch={false} target="_blank">
 					{pageDict.linkText}
 				</Link>{' '}
 				{pageDict.description2} <Link href={`mailto:${OHCRN_EMAIL}`}>{OHCRN_EMAIL}</Link>.


### PR DESCRIPTION
## Description of Changes

### Consent UI
- change __blank to _blank on a link in the informed consent page

## PR Readiness Checklist

- [x] "Expected Outcome(s)" in ticket have been met
- [x] Ticket number included in PR title
- [x] Connected ticket to PR
- [x] Labels added to PR for service name (`consent-api`, `data-mapper`, etc...), type (`chore`, `documentation`, etc...), status (`draft`, `on-hold`, etc...) **if applicable**
- [x] Manual testing completed
- [x] Builds locally without errors or warnings
- [x] Tests are updated (if required) and passing
- [ ] PR feedback has been addressed **if applicable**
- [x] New environment variables added to `.env.schema` files, `README.md`
- [x] Added copyrights to new files
