### PR TITLE
🐛 Fix Static Assets in Consent UI Docker Images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,7 @@ USER ${APP_USER}
 COPY --from=prod-deps ${CONSENT_UI_DIR}/node_modules/ ./node_modules
 COPY --from=build ${CONSENT_UI_DIR}/.next/standalone ./
 COPY --from=build ${CONSENT_UI_DIR}/.next/static ./apps/consent-ui/.next/static
+COPY --from=build ${CONSENT_UI_DIR}/public ./apps/consent-ui/public
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1


### PR DESCRIPTION
## Description of Changes

Makes assets in the `/public` directory of Consent UI available when running built Docker images.

* Copy `/public` directory to make public assets available in built Docker images of Consent UI

## PR Readiness Checklist

- [ ] "Expected Outcome(s)" in ticket have been met
- [ ] Ticket number included in PR title
- [ ] Connected ticket to PR
- [x] Labels added to PR for service name (`consent-api`, `data-mapper`, etc...), type (`chore`, `documentation`, etc...), status (`draft`, `on-hold`, etc...) **if applicable**
- [x] Manual testing completed
- [x] Builds locally without errors or warnings
- [ ] Tests are updated (if required) and passing
- [ ] PR feedback has been addressed **if applicable**
- [ ] New environment variables added to `.env.schema` files, `README.md`
- [ ] Added copyrights to new files
