### PR TITLE
285 - 🏷️ Regex types suggested changes

### DIFF
--- a/apps/consent-ui/src/components/views/Invite/ClinicianInviteForm/index.tsx
+++ b/apps/consent-ui/src/components/views/Invite/ClinicianInviteForm/index.tsx
@@ -22,7 +22,7 @@
 import { useEffect, useState } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm, SubmitHandler, FormProvider } from 'react-hook-form';
-import { ConsentGroup, InviteFieldsPreRefine, NameOptionalUI } from 'types/entities';
+import { ConsentGroup, ClinicianInviteBase, EmptyOrOptionalName } from 'types/entities';
 import { ClinicianInviteRequest } from 'types/consentApi';
 import clsx from 'clsx';
 import { useRouter } from 'next/navigation';
@@ -54,11 +54,10 @@ import formStyles from './ClinicianInviteForm.module.scss';
 
 const styles = Object.assign({}, formStyles, layoutStyles);
 
-const ClinicianInviteUI = InviteFieldsPreRefine.extend({
-	participantPreferredName: NameOptionalUI,
-}).refine(hasRequiredGuardianInformation, {
-	message: 'Guardian contact fields are required for that consentGroup',
-});
+const ClinicianInviteUI = ClinicianInviteBase.extend({
+	participantPreferredName: EmptyOrOptionalName,
+}).refine(hasRequiredGuardianInformation);
+
 type ClinicianInviteUI = z.infer<typeof ClinicianInviteUI>;
 
 const consentGroupsRequiringGuardian: ConsentGroup[] = [

--- a/packages/types/src/common/String.ts
+++ b/packages/types/src/common/String.ts
@@ -25,6 +25,8 @@ export type TrimmedString = z.infer<typeof TrimmedString>;
 export const OptionalString = TrimmedString.optional();
 export type OptionalString = z.infer<typeof OptionalString>;
 
-/** check for empty strings or whitespace */
-export const EmptyStringOrWhitespace = TrimmedString.max(0);
-export type EmptyStringOrWhitespace = z.infer<typeof EmptyStringOrWhitespace>;
+export const EmptyString = z.literal('');
+export type EmptyString = z.infer<typeof EmptyString>;
+
+export const EmptyWhiteSpace = TrimmedString.max(0);
+export type EmptyWhiteSpace = z.infer<typeof EmptyWhiteSpace>;

--- a/packages/types/src/common/String.ts
+++ b/packages/types/src/common/String.ts
@@ -17,13 +17,14 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-export * from './SortOrder.js';
-export * from './Status.js';
-export * from './String.js';
-export * from './conditionalFieldUtils.js';
-export * from './expand.js';
-export * from './keys.js';
-export * from './lengthConstraints.js';
-export * from './recursivePartial.js';
-export * from './regexes.js';
-export * from './values.js';
+import z from 'zod';
+
+export const TrimmedString = z.string().trim();
+export type TrimmedString = z.infer<typeof TrimmedString>;
+
+export const OptionalString = TrimmedString.optional();
+export type OptionalString = z.infer<typeof OptionalString>;
+
+/** check for empty strings or whitespace */
+export const EmptyStringOrWhitespace = TrimmedString.max(0);
+export type EmptyStringOrWhitespace = z.infer<typeof EmptyStringOrWhitespace>;

--- a/packages/types/src/common/regexes.ts
+++ b/packages/types/src/common/regexes.ts
@@ -20,6 +20,7 @@
 import z from 'zod';
 
 import { NANOID_LENGTH, OHIP_NUMBER_LENGTH, PHONE_NUMBER_LENGTH } from './lengthConstraints.js';
+import { EmptyStringOrWhitespace } from './String.js';
 
 // TODO: separate name into two fields with + without whitespace, include French chars in both
 export const NAME_REGEX = /^[A-Za-z\s]+$/;
@@ -46,9 +47,6 @@ export const getRegexOptionalAPISchema = (regex: RegExp) => {
 	const regexOptionalAPISchema = getRegexSchema(regex).optional();
 	return regexOptionalAPISchema;
 };
-
-/** check for empty strings or whitespace */
-const EmptyStringOrWhitespace = z.string().trim().max(0);
 
 /**
  * Makes a Zod schema for a regular expression, for optional fields in the UI.

--- a/packages/types/src/common/regexes.ts
+++ b/packages/types/src/common/regexes.ts
@@ -17,10 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import z from 'zod';
-
 import { NANOID_LENGTH, OHIP_NUMBER_LENGTH, PHONE_NUMBER_LENGTH } from './lengthConstraints.js';
-import { EmptyStringOrWhitespace } from './String.js';
 
 // TODO: separate name into two fields with + without whitespace, include French chars in both
 export const NAME_REGEX = /^[A-Za-z\s]+$/;
@@ -30,31 +27,3 @@ export const PHONE_NUMBER_REGEX = new RegExp(`^[0-9]{${PHONE_NUMBER_LENGTH}}$`);
 export const POSTAL_CODE_REGEX = /^[A-Za-z][0-9][A-Za-z][0-9][A-Za-z][0-9]$/;
 
 export const REGEX_FLAG_GLOBAL = 'g';
-
-/**
- * Make a Zod schema for a regular expression, for required fields.
- */
-export const getRegexSchema = (regex: RegExp) => {
-	const regexSchema = z.string().trim().regex(regex);
-	return regexSchema;
-};
-
-/**
- * Make a Zod schema for a regular expression, for optional fields in the API.
- * The resulting schema will allow inputs that match the regex, and undefined values.
- */
-export const getRegexOptionalAPISchema = (regex: RegExp) => {
-	const regexOptionalAPISchema = getRegexSchema(regex).optional();
-	return regexOptionalAPISchema;
-};
-
-/**
- * Makes a Zod schema for a regular expression, for optional fields in the UI.
- * Allows fields that match the regex, undefined values, and
- * empty or whitespace-only strings, because empty HTML inputs contain empty strings
- * rather than undefined values.
- */
-export const getRegexOptionalUISchema = (regex: RegExp) => {
-	const regexOptionalUISchema = getRegexSchema(regex).or(EmptyStringOrWhitespace).optional();
-	return regexOptionalUISchema;
-};

--- a/packages/types/src/entities/ClinicianInvite.ts
+++ b/packages/types/src/entities/ClinicianInvite.ts
@@ -21,7 +21,7 @@ import { z } from 'zod';
 
 // import { hasRequiredGuardianInformation } from '../common/index.js';
 
-import { ConsentGroup, Name, NameOptionalAPI, NanoId } from './fields/index.js';
+import { ConsentGroup, Name, NanoId } from './fields/index.js';
 import { GuardianBaseFields } from './Guardian.js';
 import {
 	ConsentToBeContacted,
@@ -49,7 +49,7 @@ export const InviteGuardianFields = GuardianBaseFields;
 export type InviteGuardianFields = z.infer<typeof InviteGuardianFields>;
 
 export const InviteParticipantFields = ParticipantNameFields.merge(
-	z.object({ participantPreferredName: NameOptionalAPI }),
+	z.object({ participantPreferredName: Name.optional() }),
 ).merge(ParticipantContactFields);
 export type InviteParticipantFields = z.infer<typeof InviteParticipantFields>;
 

--- a/packages/types/src/entities/ClinicianInvite.ts
+++ b/packages/types/src/entities/ClinicianInvite.ts
@@ -19,7 +19,7 @@
 
 import { z } from 'zod';
 
-import { hasRequiredGuardianInformation } from '../common/index.js';
+// import { hasRequiredGuardianInformation } from '../common/index.js';
 
 import { ConsentGroup, Name, NameOptionalAPI, NanoId } from './fields/index.js';
 import { GuardianBaseFields } from './Guardian.js';
@@ -60,10 +60,14 @@ export const InviteEntity = z.object({
 	inviteAccepted: z.boolean().default(false),
 });
 
-export const InviteFieldsPreRefine =
-	InviteClinicianFields.merge(InviteGuardianFields).merge(InviteParticipantFields);
+// export const InviteFieldsPreRefine =
+// 	InviteClinicianFields.merge(InviteGuardianFields).merge(InviteParticipantFields);
 
-// base type req/res for the "full" invite types used in consent-api and data-mapper
-export const ClinicianInviteBase = InviteFieldsPreRefine.refine(hasRequiredGuardianInformation, {
-	message: 'Guardian contact fields are required for that consentGroup',
-});
+// // base type req/res for the "full" invite types used in consent-api and data-mapper
+// export const ClinicianInviteBase = InviteFieldsPreRefine.refine(hasRequiredGuardianInformation, {
+// 	message: 'Guardian contact fields are required for that consentGroup',
+// });
+
+export const ClinicianInviteBase =
+	InviteClinicianFields.merge(InviteGuardianFields).merge(InviteParticipantFields);
+export type ClinicianInviteBase = z.infer<typeof ClinicianInviteBase>;

--- a/packages/types/src/entities/ClinicianInvite.ts
+++ b/packages/types/src/entities/ClinicianInvite.ts
@@ -60,14 +60,6 @@ export const InviteEntity = z.object({
 	inviteAccepted: z.boolean().default(false),
 });
 
-// export const InviteFieldsPreRefine =
-// 	InviteClinicianFields.merge(InviteGuardianFields).merge(InviteParticipantFields);
-
-// // base type req/res for the "full" invite types used in consent-api and data-mapper
-// export const ClinicianInviteBase = InviteFieldsPreRefine.refine(hasRequiredGuardianInformation, {
-// 	message: 'Guardian contact fields are required for that consentGroup',
-// });
-
 export const ClinicianInviteBase =
 	InviteClinicianFields.merge(InviteGuardianFields).merge(InviteParticipantFields);
 export type ClinicianInviteBase = z.infer<typeof ClinicianInviteBase>;

--- a/packages/types/src/entities/fields/Name.ts
+++ b/packages/types/src/entities/fields/Name.ts
@@ -19,18 +19,20 @@
 
 import { z } from 'zod';
 
-import {
-	getRegexOptionalAPISchema,
-	getRegexOptionalUISchema,
-	getRegexSchema,
-	NAME_REGEX,
-} from '../../common/regexes.js';
+import { EmptyString, EmptyWhiteSpace, TrimmedString } from '../../common/String.js';
+import { NAME_REGEX } from '../../common/regexes.js';
 
-export const Name = getRegexSchema(NAME_REGEX);
+// trimmed string with regex
+export const Name = TrimmedString.regex(NAME_REGEX);
 export type Name = z.infer<typeof Name>;
 
-export const NameOptionalAPI = getRegexOptionalAPISchema(NAME_REGEX);
-export type NameOptionalAPI = z.infer<typeof NameOptionalAPI>;
+// optional trimmed string with regex
+export const OptionalName = TrimmedString.regex(NAME_REGEX).optional();
+export type OptionalName = z.infer<typeof OptionalName>;
 
-export const NameOptionalUI = getRegexOptionalUISchema(NAME_REGEX);
-export type NameOptionalUI = z.infer<typeof NameOptionalUI>;
+// optional trimmed string with regex OR empty/whitespace string
+export const EmptyOrOptionalName = TrimmedString.regex(NAME_REGEX)
+	.optional()
+	.or(EmptyString)
+	.or(EmptyWhiteSpace);
+export type EmptyOrOptionalName = z.infer<typeof EmptyOrOptionalName>;

--- a/packages/types/src/services/consentApi/requests/ClinicianInvite.ts
+++ b/packages/types/src/services/consentApi/requests/ClinicianInvite.ts
@@ -21,8 +21,9 @@ import { generateSchema } from '@anatine/zod-openapi';
 import type { SchemaObject } from 'openapi3-ts/oas31';
 import { z } from 'zod';
 
+import { hasRequiredGuardianInformation } from '../../../common/index.js';
 import { ClinicianInviteBase } from '../../../entities/ClinicianInvite.js';
 
-export const ClinicianInviteRequest = ClinicianInviteBase;
+export const ClinicianInviteRequest = ClinicianInviteBase.refine(hasRequiredGuardianInformation);
 export type ClinicianInviteRequest = z.infer<typeof ClinicianInviteBase>;
 export const ClinicianInviteRequestSchema: SchemaObject = generateSchema(ClinicianInviteBase);

--- a/packages/types/src/services/consentApi/responses/ClinicianInvite.ts
+++ b/packages/types/src/services/consentApi/responses/ClinicianInvite.ts
@@ -21,9 +21,12 @@ import { z } from 'zod';
 import { generateSchema } from '@anatine/zod-openapi';
 import type { SchemaObject } from 'openapi3-ts/oas31';
 
+import { hasRequiredGuardianInformation } from '../../../common/index.js';
 import { InviteEntity, ClinicianInviteBase } from '../../../entities/index.js';
 
-export const ClinicianInvite = InviteEntity.and(ClinicianInviteBase);
+export const ClinicianInvite = InviteEntity.merge(ClinicianInviteBase).refine(
+	hasRequiredGuardianInformation,
+);
 export type ClinicianInvite = z.infer<typeof ClinicianInvite>;
 
 export const ClinicianInviteResponse = ClinicianInvite;

--- a/packages/types/src/services/dataMapper/requests/ClinicianInvite.ts
+++ b/packages/types/src/services/dataMapper/requests/ClinicianInvite.ts
@@ -21,8 +21,10 @@ import { generateSchema } from '@anatine/zod-openapi';
 import type { SchemaObject } from 'openapi3-ts/oas31';
 import { z } from 'zod';
 
+import { hasRequiredGuardianInformation } from 'src/common/index.js';
+
 import { ClinicianInviteBase } from '../../../entities/ClinicianInvite.js';
 
-export const ClinicianInviteRequest = ClinicianInviteBase;
+export const ClinicianInviteRequest = ClinicianInviteBase.refine(hasRequiredGuardianInformation);
 export type ClinicianInviteRequest = z.infer<typeof ClinicianInviteBase>;
 export const ClinicianInviteRequestSchema: SchemaObject = generateSchema(ClinicianInviteBase);

--- a/packages/types/src/services/dataMapper/responses/ClinicianInvite.ts
+++ b/packages/types/src/services/dataMapper/responses/ClinicianInvite.ts
@@ -23,7 +23,7 @@ import type { SchemaObject } from 'openapi3-ts/oas31';
 
 import { InviteEntity, ClinicianInviteBase } from '../../../entities/index.js';
 
-export const ClinicianInvite = InviteEntity.and(ClinicianInviteBase);
+export const ClinicianInvite = InviteEntity.merge(ClinicianInviteBase);
 export type ClinicianInvite = z.infer<typeof ClinicianInvite>;
 
 export const ClinicianInviteResponse = ClinicianInvite;

--- a/packages/types/tests/entities/ClinicianInvite.spec.ts
+++ b/packages/types/tests/entities/ClinicianInvite.spec.ts
@@ -22,11 +22,11 @@ import { describe, expect, it } from 'vitest';
 import { ConsentGroup } from '../../src/entities/fields/index.js';
 import { ConsentClinicianInviteResponse } from '../../src/services/consentDas/index.js';
 import { PIClinicianInviteResponse } from '../../src/services/piDas/index.js';
-import { ClinicianInviteResponse } from '../../src/services/consentApi/responses/ClinicianInvite.js';
+import { ClinicianInviteRequest } from '../../src/services/consentApi/requests/ClinicianInvite.js';
 
 describe('ClinicianInviteResponse', () => {
 	it('Parses correctly when consentGroup is GUARDIAN_CONSENT_OF_MINOR and all guardian contact fields are provided', () => {
-		const result = ClinicianInviteResponse.safeParse({
+		const result = ClinicianInviteRequest.safeParse({
 			id: 'CVCFbeKH2Njl1G41vCQme',
 			inviteSentDate: new Date(),
 			clinicianFirstName: 'Homer',
@@ -47,7 +47,7 @@ describe('ClinicianInviteResponse', () => {
 		expect(result.success).true;
 	});
 	it('Parses correctly when consentGroup is GUARDIAN_CONSENT_OF_MINOR_INCLUDING_ASSENT and all guardian contact fields are provided', () => {
-		const result = ClinicianInviteResponse.safeParse({
+		const result = ClinicianInviteRequest.safeParse({
 			id: 'CVCFbeKH2Njl1G41vCQme',
 			inviteSentDate: new Date(),
 			clinicianFirstName: 'Homer',
@@ -68,7 +68,7 @@ describe('ClinicianInviteResponse', () => {
 		expect(result.success).true;
 	});
 	it('Fails when consentGroup is GUARDIAN_CONSENT_OF_MINOR and some guardian contact fields are NOT provided', () => {
-		const result = ClinicianInviteResponse.safeParse({
+		const result = ClinicianInviteRequest.safeParse({
 			id: 'CVCFbeKH2Njl1G41vCQme',
 			inviteSentDate: new Date(),
 			clinicianFirstName: 'Homer',
@@ -87,7 +87,7 @@ describe('ClinicianInviteResponse', () => {
 		expect(result.success).false;
 	});
 	it('Fails when consentGroup is GUARDIAN_CONSENT_OF_MINOR_INCLUDING_ASSENT and all guardian contact fields are NOT provided', () => {
-		const result = ClinicianInviteResponse.safeParse({
+		const result = ClinicianInviteRequest.safeParse({
 			id: 'CVCFbeKH2Njl1G41vCQme',
 			inviteSentDate: new Date(),
 			clinicianFirstName: 'Homer',

--- a/packages/types/tests/entities/ClinicianInvite.spec.ts
+++ b/packages/types/tests/entities/ClinicianInvite.spec.ts
@@ -20,13 +20,13 @@
 import { describe, expect, it } from 'vitest';
 
 import { ConsentGroup } from '../../src/entities/fields/index.js';
-import { ClinicianInviteBase } from '../../src/entities/index.js';
 import { ConsentClinicianInviteResponse } from '../../src/services/consentDas/index.js';
 import { PIClinicianInviteResponse } from '../../src/services/piDas/index.js';
+import { ClinicianInviteResponse } from '../../src/services/consentApi/responses/ClinicianInvite.js';
 
 describe('ClinicianInviteResponse', () => {
 	it('Parses correctly when consentGroup is GUARDIAN_CONSENT_OF_MINOR and all guardian contact fields are provided', () => {
-		const result = ClinicianInviteBase.safeParse({
+		const result = ClinicianInviteResponse.safeParse({
 			id: 'CVCFbeKH2Njl1G41vCQme',
 			inviteSentDate: new Date(),
 			clinicianFirstName: 'Homer',
@@ -47,7 +47,7 @@ describe('ClinicianInviteResponse', () => {
 		expect(result.success).true;
 	});
 	it('Parses correctly when consentGroup is GUARDIAN_CONSENT_OF_MINOR_INCLUDING_ASSENT and all guardian contact fields are provided', () => {
-		const result = ClinicianInviteBase.safeParse({
+		const result = ClinicianInviteResponse.safeParse({
 			id: 'CVCFbeKH2Njl1G41vCQme',
 			inviteSentDate: new Date(),
 			clinicianFirstName: 'Homer',
@@ -68,7 +68,7 @@ describe('ClinicianInviteResponse', () => {
 		expect(result.success).true;
 	});
 	it('Fails when consentGroup is GUARDIAN_CONSENT_OF_MINOR and some guardian contact fields are NOT provided', () => {
-		const result = ClinicianInviteBase.safeParse({
+		const result = ClinicianInviteResponse.safeParse({
 			id: 'CVCFbeKH2Njl1G41vCQme',
 			inviteSentDate: new Date(),
 			clinicianFirstName: 'Homer',
@@ -87,7 +87,7 @@ describe('ClinicianInviteResponse', () => {
 		expect(result.success).false;
 	});
 	it('Fails when consentGroup is GUARDIAN_CONSENT_OF_MINOR_INCLUDING_ASSENT and all guardian contact fields are NOT provided', () => {
-		const result = ClinicianInviteBase.safeParse({
+		const result = ClinicianInviteResponse.safeParse({
 			id: 'CVCFbeKH2Njl1G41vCQme',
 			inviteSentDate: new Date(),
 			clinicianFirstName: 'Homer',

--- a/packages/types/tests/entities/Name.spec.ts
+++ b/packages/types/tests/entities/Name.spec.ts
@@ -22,11 +22,17 @@ import { describe, expect, it } from 'vitest';
 import { Name, OptionalName, EmptyOrOptionalName } from '../../src/entities/fields/index.js';
 
 describe('Name', () => {
-	// tests for Name
+	it('Can be a string containing only letters', () => {
+		expect(Name.safeParse('Simpson').success).true;
+	});
+	// add necessary tests
 });
 
 describe('OptionalName', () => {
-	// tests for OptionalName
+	it('Can be a string containing only letters', () => {
+		expect(OptionalName.safeParse('Simpson').success).true;
+	});
+	// add necessary tests
 });
 
 // TODO: add tests for special characters (accented letters) when added to the NAME_REGEX

--- a/packages/types/tests/entities/Name.spec.ts
+++ b/packages/types/tests/entities/Name.spec.ts
@@ -19,52 +19,62 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { Name, NameOptionalAPI, NameOptionalUI } from '../../src/entities/fields/index.js';
+import { Name, OptionalName, EmptyOrOptionalName } from '../../src/entities/fields/index.js';
 
 describe('Name', () => {
-	it('Can only contain letters and whitespace', () => {
-		expect(Name.safeParse('Homer Simpson').success).true;
-		expect(Name.safeParse('homer simpson').success).true;
-		expect(Name.safeParse('Homer Simpon!').success).false;
-		expect(Name.safeParse("D'oh").success).false;
-		expect(Name.safeParse('Homer_Simpson').success).false;
-		expect(Name.safeParse('-Homer Simpson').success).false;
-		expect(Name.safeParse('Homer Simpson1').success).false;
-		expect(Name.safeParse(undefined).success).false;
-		expect(Name.safeParse(null).success).false;
-		expect(Name.safeParse('').success).false;
-		expect(Name.safeParse(' ').success).false;
-	});
+	// tests for Name
 });
 
-describe('NameOptionalAPI', () => {
-	it('Can only contain letters and whitespace, or undefined', () => {
-		expect(NameOptionalAPI.safeParse('Homer Simpson').success).true;
-		expect(NameOptionalAPI.safeParse('homer simpson').success).true;
-		expect(NameOptionalAPI.safeParse('Homer Simpon!').success).false;
-		expect(NameOptionalAPI.safeParse("D'oh").success).false;
-		expect(NameOptionalAPI.safeParse('Homer_Simpson').success).false;
-		expect(NameOptionalAPI.safeParse('-Homer Simpson').success).false;
-		expect(NameOptionalAPI.safeParse('Homer Simpson1').success).false;
-		expect(NameOptionalAPI.safeParse(undefined).success).true;
-		expect(NameOptionalAPI.safeParse(null).success).false;
-		expect(NameOptionalAPI.safeParse('').success).false;
-		expect(NameOptionalAPI.safeParse(' ').success).false;
-	});
+describe('OptionalName', () => {
+	// tests for OptionalName
 });
 
-describe('NameOptionalUI', () => {
-	it('Can only contain letters and whitespace, empty strings, or undefined', () => {
-		expect(NameOptionalUI.safeParse('Homer Simpson').success).true;
-		expect(NameOptionalUI.safeParse('homer simpson').success).true;
-		expect(NameOptionalUI.safeParse('Homer Simpon!').success).false;
-		expect(NameOptionalUI.safeParse("D'oh").success).false;
-		expect(NameOptionalUI.safeParse('Homer_Simpson').success).false;
-		expect(NameOptionalUI.safeParse('-Homer Simpson').success).false;
-		expect(NameOptionalUI.safeParse('Homer Simpson1').success).false;
-		expect(NameOptionalUI.safeParse(undefined).success).true;
-		expect(NameOptionalUI.safeParse(null).success).false;
-		expect(NameOptionalUI.safeParse('').success).true;
-		expect(NameOptionalUI.safeParse(' ').success).true;
+// TODO: add tests for special characters (accented letters) when added to the NAME_REGEX
+describe('EmptyOrOptionalName', () => {
+	it('Can be a string containing only letters', () => {
+		expect(EmptyOrOptionalName.safeParse('Simpson').success).true;
+	});
+
+	it('Can be a string containing letters and spaces', () => {
+		expect(EmptyOrOptionalName.safeParse('Homer Simpson').success).true;
+		expect(EmptyOrOptionalName.safeParse('homer simpson').success).true;
+	});
+
+	it('Can be undefined', () => {
+		expect(EmptyOrOptionalName.safeParse(undefined).success).true;
+	});
+
+	it('Can be an empty string', () => {
+		expect(EmptyOrOptionalName.safeParse('').success).true;
+	});
+
+	it('Can be a string containing only whitespace', () => {
+		expect(EmptyOrOptionalName.safeParse(' ').success).true;
+	});
+
+	it('Can be a string containing letters and whitespace', () => {
+		expect(EmptyOrOptionalName.safeParse('homer      simpson').success).true;
+	});
+
+	it('Cannot be a string containing letters and numbers', () => {
+		expect(EmptyOrOptionalName.safeParse('HomerSimpson1').success).false;
+	});
+
+	it('Cannot be a string containing letters, numbers and spaces', () => {
+		expect(EmptyOrOptionalName.safeParse('Homer Simpson 1').success).false;
+	});
+
+	it('Cannot be a string containing only non-alphanumeric characters', () => {
+		expect(EmptyOrOptionalName.safeParse('-_-').success).false;
+		expect(EmptyOrOptionalName.safeParse("''").success).false;
+		expect(EmptyOrOptionalName.safeParse('!!').success).false;
+		expect(EmptyOrOptionalName.safeParse('*?').success).false;
+	});
+
+	it('Cannot be a string containing letters or numbers and non-alphanumeric characters', () => {
+		expect(EmptyOrOptionalName.safeParse('-Homer Simpson').success).false;
+		expect(EmptyOrOptionalName.safeParse("D'oh").success).false;
+		expect(EmptyOrOptionalName.safeParse('Homer_Simpson3').success).false;
+		expect(EmptyOrOptionalName.safeParse('Homer Simpon!').success).false;
 	});
 });


### PR DESCRIPTION
## Description of Changes

Suggestions for https://github.com/OHCRN/platform/pull/431. Not exhaustively tested in the UI form, so please verify this matches the intended behaviour!

### Consent UI
- Adds `EmptyOrOptionalName` as the field type for `participantPreferredName` on the invite form to pass validation if the field is an empty string

### Types
- adds convenience String types for trimmed and optional strings that can be chained with `z.regex()`. Also adds literal empty string and whitespace types
- adds 'OptionalName` and `EmptyOrOptionalName` types
- updates `Name` test with cases for `EmptyOrOptionalName` type. Tests for `Name` and `OptionalName` need to be implemented
- updates `ClinicianInvite` test to use `ClinicianInviteRequest` schema instead of `ClinicianInviteResponse` schema

### Special Instructions
Before running these changes, you will need to install `package name`:
```
pnpm run build for `types` package
```

## PR Readiness Checklist

- [ ] "Expected Outcome(s)" in ticket have been met
- [ ] Ticket number included in PR title
- [ ] Connected ticket to PR
- [ ] Labels added to PR for service name (`consent-api`, `data-mapper`, etc...), type (`chore`, `documentation`, etc...), status (`draft`, `on-hold`, etc...) **if applicable**
- [ ] Manual testing completed
- [ ] Builds locally without errors or warnings
- [ ] Tests are updated (if required) and passing
- [ ] PR feedback has been addressed **if applicable**
- [ ] New environment variables added to `.env.schema` files, `README.md`
- [ ] Added copyrights to new files
