### PR TITLE
🗃️#458: Add missing fields for data model v5.0

### DIFF
--- a/apps/phi-das/prisma/migrations/20240307194322_data_model_v5_update/migration.sql
+++ b/apps/phi-das/prisma/migrations/20240307194322_data_model_v5_update/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "VitalStatus" AS ENUM ('ALIVE', 'DECEASED');
+
+-- AlterTable
+ALTER TABLE "ClinicalProfile" ADD COLUMN     "vitalStatus" "VitalStatus";

--- a/apps/phi-das/prisma/schema.prisma
+++ b/apps/phi-das/prisma/schema.prisma
@@ -334,6 +334,11 @@ enum MolecularLab {
   UNIVERSITY_HEALTH_NETWORK_TORONTO
 }
 
+enum VitalStatus {
+  ALIVE
+  DECEASED
+}
+
 model ClinicalProfile {
   clinicalProfilePrivateKey         String          @id @db.Char(21)
   ancestry                          Ancestry
@@ -347,4 +352,5 @@ model ClinicalProfile {
   selfReportedMolecularLabVisited   MolecularLab?
   historyOfCancer                   HistoryOfCancer
   selfIdentifiedGender              String?
+  vitalStatus                       VitalStatus?
 }

--- a/apps/pi-das/prisma/migrations/20240307194410_data_model_v5_update/migration.sql
+++ b/apps/pi-das/prisma/migrations/20240307194410_data_model_v5_update/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "ClinicianInvite" ADD COLUMN     "assentFormIdentifier" TEXT;
+
+-- AlterTable
+ALTER TABLE "Participant" ADD COLUMN     "assentFormIdentifier" TEXT;

--- a/apps/pi-das/prisma/schema.prisma
+++ b/apps/pi-das/prisma/schema.prisma
@@ -48,6 +48,7 @@ model Participant {
   mailingAddressProvince    Province?
   mailingAddressPostalCode  String?          @db.Char(6)
   residentialPostalCode     String?          @db.Char(6)
+  assentFormIdentifier      String?
 }
 
 model ClinicianInvite {
@@ -62,4 +63,5 @@ model ClinicianInvite {
   guardianEmailAddress     String?
   guardianRelationship     String?
   Participant              Participant[]
+  assentFormIdentifier     String?
 }


### PR DESCRIPTION
## Description of Changes

Add missing fields for data model v5.0

PI DAS
- Participant table
   - assentFormIdentifier (optional, string)
   - hasOhip (required, boolean, default true) (ALREADY ADDED IN ANOTHER PR)
- Clinician Invites table
   - assentFormIdentifier (optional, string)
 
PHI DAS
- Clinical Profile table
   - vitalStatus

### Special Instructions
Before running these changes, you will need run migrations
```
pnpm prisma:generate
```
## PR Readiness Checklist

- [x] "Expected Outcome(s)" in ticket have been met
- [x] Ticket number included in PR title
- [x] Connected ticket to PR
- [x] Labels added to PR for service name (`consent-api`, `data-mapper`, etc...), type (`chore`, `documentation`, etc...), status (`draft`, `on-hold`, etc...) **if applicable**
- [x] Manual testing completed
- [x] Builds locally without errors or warnings
- [x] Tests are updated (if required) and passing
- [ ] PR feedback has been addressed **if applicable**
- [x] New environment variables added to `.env.schema` files, `README.md`
- [x] Added copyrights to new files
