### PR TITLE
🐛 bugfix: change how ReactModal finds root element

### DIFF
--- a/apps/consent-ui/src/components/common/Modal/index.tsx
+++ b/apps/consent-ui/src/components/common/Modal/index.tsx
@@ -65,9 +65,9 @@ const Modal = ({
 	onCancelClick,
 	title,
 }: ModalProps) => {
+	ReactModal.setAppElement('#root');
 	return (
 		<ReactModal
-			appElement={document.getElementById('root') as HTMLElement}
 			className={styles.modal}
 			contentLabel={contentLabel}
 			isOpen={modalIsOpen}


### PR DESCRIPTION
## Description of Changes

### Consent UI
- change how ReactModal finds root element, because server components don't have access to the window/document object
  - the error was being thrown in the terminal not the browser console, because it's a server component

## PR Readiness Checklist

- [x] "Expected Outcome(s)" in ticket have been met
- [x] Ticket number included in PR title
- [x] Connected ticket to PR
- [x] Labels added to PR for service name (`consent-api`, `data-mapper`, etc...), type (`chore`, `documentation`, etc...), status (`draft`, `on-hold`, etc...) **if applicable**
- [x] Manual testing completed
- [x] Builds locally without errors or warnings
- [x] Tests are updated (if required) and passing
- [x] PR feedback has been addressed **if applicable**
- [x] New environment variables added to `.env.schema` files, `README.md`
- [x] Added copyrights to new files
