### PR TITLE
customize encoding, saltLength to decrease cookie size

### DIFF
--- a/apps/consent-ui/src/components/common/Header/Header.tsx
+++ b/apps/consent-ui/src/components/common/Header/Header.tsx
@@ -108,7 +108,7 @@ const Header = ({ currentLang, textDict, session }: HeaderContentProps) => {
 						{/* Desktop */}
 						<div className={styles.desktopUserMenu}>
 							{session?.user ? (
-								<div>Hello, {session.user.preferredUsername}</div>
+								<div>Hello, {session.user.username}</div>
 							) : (
 								<LoginButton currentLang={currentLang} />
 							)}

--- a/apps/consent-ui/src/services/api/utils/encryption.ts
+++ b/apps/consent-ui/src/services/api/utils/encryption.ts
@@ -24,8 +24,16 @@ import { getAppConfig } from 'src/config';
 const { TOKEN_ENCRYPTION_KEY } = getAppConfig();
 const BUILDTIME_PLACEHOLDER_KEY = 'supersecretz';
 // BUILDTIME_PLACEHOLDER_KEY will be replaced by TOKEN_ENCRYPTION_KEY from runtime vars
+
+const ENCODING = 'base64';
+const SALT_LENGTH = 32;
+
 const cryptr = new Cryptr(
 	process.env.NEXT_IS_BUILDING ? BUILDTIME_PLACEHOLDER_KEY : TOKEN_ENCRYPTION_KEY,
+	{
+		encoding: ENCODING,
+		saltLength: SALT_LENGTH,
+	},
 );
 
 export const encryptContent = (value: string) => {


### PR DESCRIPTION
## Description of Changes

The cookies produced by Next-Auth and the default encryption from `cryptr` when the Keycloak `access_token` and `id_token` are added to the session are quite large (over 9kb), and we ran into issues with the Nginx proxy on the dev env. With the default proxy buffer size the callback from Keycloak to Consent UI produced a `502 - Bad Gateway`, and increasing the size produced a `400 - Request Header Too Large`. Next-Auth does split the session across multiple cookies but the overall size is still too large. We're still doing some debugging with IT for possible options, but we may be able to reduce the cookie size with some changes to the encryption and keycloak token settings:

Using a `base64` encoding and a shorter saltLength helps to decrease the cookie size. Combining this with a different signing algo on the Keycloak token (`ES256` instead of the default `RS256`) helps reduce the size even further:

"All tokens" = `access_token`, `id_token` and `refresh_token`

encoding: `hex` + algo: `RS256` with all tokens:
3958 + 3958 + 3145 bytes

encoding: `base64` + algo: `RS256`, with all tokens
3958 + 3625 bytes

encoding: `base64` + algo: `ES256`, with all tokens
3958 + 2729 bytes

**Note**: this issue _might_ be related to another 502 issue: https://github.com/OHCRN/platform/issues/447

### Consent UI
- Encryption setting changes, as noted above
- Adds `refresh_token` to Next-Auth session
- accessor name change for `username`

## PR Readiness Checklist

- [ ] "Expected Outcome(s)" in ticket have been met
- [ ] Ticket number included in PR title
- [ ] Connected ticket to PR
- [x] Labels added to PR for service name (`consent-api`, `data-mapper`, etc...), type (`chore`, `documentation`, etc...), status (`draft`, `on-hold`, etc...) **if applicable**
- [x] Manual testing completed
- [ ] Builds locally without errors or warnings
- [ ] Tests are updated (if required) and passing
- [ ] PR feedback has been addressed **if applicable**
- [ ] New environment variables added to `.env.schema` files, `README.md`
- [ ] Added copyrights to new files
