### PR TITLE
fix incorrect dictionary import

### DIFF
--- a/apps/consent-ui/src/i18n/locales/fr/consentResearchParticipationForm.ts
+++ b/apps/consent-ui/src/i18n/locales/fr/consentResearchParticipationForm.ts
@@ -19,7 +19,7 @@
 
 import { ConsentResearchParticipationFormDictionary } from 'src/i18n/locales/en/consentResearchParticipationForm';
 
-import formLabels from '../en/formLabels';
+import formLabels from './formLabels';
 
 const { yes, no } = formLabels;
 


### PR DESCRIPTION
## Description of Changes

No ticket - just noticed when reviewing another pr

### Consent UI
Fixes an incorrect import for the `yes`/`no` form label in step 3 of the wizard

- [x] "Expected Outcome(s)" in ticket have been met
- [ ] Ticket number included in PR title
- [ ] Connected ticket to PR
- [x] Labels added to PR for service name (`consent-api`, `data-mapper`, etc...), type (`chore`, `documentation`, etc...), status (`draft`, `on-hold`, etc...) **if applicable**
- [ ] Manual testing completed
- [x] Builds locally without errors or warnings
- [ ] Tests are updated (if required) and passing
- [ ] PR feedback has been addressed **if applicable**
- [ ] New environment variables added to `.env.schema` files, `README.md`
- [ ] Added copyrights to new files
