### PR TITLE
DO NOT MERGE - Random middleware that modifies request, and usage

### DIFF
--- a/apps/consent-api/src/middleware/random.ts
+++ b/apps/consent-api/src/middleware/random.ts
@@ -1,0 +1,23 @@
+import { RequestHandler } from 'express';
+
+declare global {
+	// eslint-disable-next-line @typescript-eslint/no-namespace
+	namespace Express {
+		interface Request {
+			random?: {
+				randomResult: number;
+			};
+		}
+	}
+}
+
+export const randomAccessMiddleware: RequestHandler = (req, res, next) => {
+	const randomResult = Math.ceil(Math.random() * 20);
+	if (randomResult < 5) {
+		return res
+			.status(400)
+			.json({ result: randomResult, message: 'You rolled too low to access this resource.' });
+	}
+	req.random = { randomResult };
+	next();
+};

--- a/apps/consent-api/src/routers/status.ts
+++ b/apps/consent-api/src/routers/status.ts
@@ -21,6 +21,7 @@ import { Router } from 'express';
 import { APIStatus } from 'types/common';
 
 import packageJson from '../../package.json' assert { type: 'json' };
+import { randomAccessMiddleware } from '../middleware/random.js';
 
 /**
  * @openapi
@@ -50,6 +51,14 @@ router.get('/', async (req, res) => {
 	const response: APIStatus = { status: `API is healthy.`, version: packageJson.version };
 
 	return res.json(response);
+});
+
+router.get('/random', randomAccessMiddleware, (req, res) => {
+	if (req.random) {
+		return res.json({ success: true, message: "You're so lucky", result: req.random.randomResult });
+	}
+
+	return res.status(500).json({ success: false, message: 'Did not receive random access check.' });
 });
 
 export default router;


### PR DESCRIPTION
> *WARN*: DO NOT MERGE - Just code example, not meant for deployment. Please close and delete branch once you have reviewed.

Example code to quickly demo how to maintain types when modifying the request object with a middleware function.

A real example might be an Authorization check that is done before passing user information to the request handler.

The example middleware is `randomAccessMiddleware`, which rolls a d20 and on a roll lower than 5 the request is failed  with status 400 stating the user is not lucky enough (placeholder for an auth failure or similar failure result from a real middleware check). On success, the result of the d20 roll is added to the request object (placeholder for adding user data to the request object).

A TS declaration is included in the middleware file to globally modify the structure of the Express Request interface. TS interfaces are extended with a declaration of this type, instead of being overwritten. This allows us to put data into a custom property on the Request object and to read from teh same object. When doing this, the property needs to be made optional since the Request object is initialized before the middleware runs and is therefore initialized without this data. This allows us to know if the random middleware was run based on whether or not the added property (`req.random` in this case) has a value. If there is an object in `req.random` then we know the middleware was run and it will have the required structure (TS enforced).