### PR TITLE
🔧 Enforce server-only Usage for App Config and Client App Config

### DIFF
--- a/apps/consent-ui/src/components/providers/AppConfigContextProvider/index.tsx
+++ b/apps/consent-ui/src/components/providers/AppConfigContextProvider/index.tsx
@@ -21,7 +21,7 @@
 
 import { ReactNode, createContext, useContext } from 'react';
 
-import { ClientAppConfig, defaultClientAppConfig } from 'src/config';
+import { ClientAppConfig, defaultClientAppConfig } from 'src/config/types';
 
 const AppConfigContext = createContext(defaultClientAppConfig);
 

--- a/apps/consent-ui/src/components/views/Dashboard/TempPdfButtons.tsx
+++ b/apps/consent-ui/src/components/views/Dashboard/TempPdfButtons.tsx
@@ -39,9 +39,11 @@ import { settingsByLang } from './generateConsentPdf/settings';
 const TempPdfButtons = ({
 	currentLang,
 	studyConsentPdfUrl,
+	mockSignatureImage,
 }: {
 	currentLang: ValidLanguage;
 	studyConsentPdfUrl: string;
+	mockSignatureImage: string;
 }) => {
 	const [docUrl, setDocUrl] = useState<string | undefined>();
 
@@ -61,22 +63,40 @@ const TempPdfButtons = ({
 	};
 
 	const displayParticipantPdf = async () => {
-		await displayPdf(mockDataParticipant);
+		await displayPdf({
+			...mockDataParticipant,
+			mockSignatureImage,
+		});
 	};
 	const displaySubstitutePdf = async () => {
-		await displayPdf(mockDataSubstitute);
+		await displayPdf({
+			...mockDataSubstitute,
+			mockSignatureImage,
+		});
 	};
 	const displayGuardianPdf = async () => {
-		await displayPdf(mockDataGuardian);
+		await displayPdf({
+			...mockDataGuardian,
+			mockSignatureImage,
+		});
 	};
 	const downloadParticipantPdf = async () => {
-		await downloadPdf(mockDataParticipant);
+		await downloadPdf({
+			...mockDataParticipant,
+			mockSignatureImage,
+		});
 	};
 	const downloadSubstitutePdf = async () => {
-		await downloadPdf(mockDataSubstitute);
+		await downloadPdf({
+			...mockDataSubstitute,
+			mockSignatureImage,
+		});
 	};
 	const downloadGuardianPdf = async () => {
-		await downloadPdf(mockDataGuardian);
+		await downloadPdf({
+			...mockDataGuardian,
+			mockSignatureImage,
+		});
 	};
 
 	return (

--- a/apps/consent-ui/src/components/views/Dashboard/TempPdfButtonsWrapper.tsx
+++ b/apps/consent-ui/src/components/views/Dashboard/TempPdfButtonsWrapper.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import urlJoin from 'url-join';
+
+import { getAppConfig } from 'src/config';
+import { ASSETS_PATH, CONSENT_PDFS_PATH } from 'src/constants';
+import { getTranslation, ValidLanguage } from 'src/i18n';
+
+import TempPdfButtons from './TempPdfButtons';
+
+const TempPdfButtonsWrapper = ({ currentLang }: { currentLang: ValidLanguage }) => {
+	const { CONSENT_UI_URL } = getAppConfig();
+	const { translate } = getTranslation(currentLang);
+
+	const studyConsentPdfUrl = urlJoin(
+		ASSETS_PATH,
+		CONSENT_PDFS_PATH,
+		translate('assetUrls', 'studyConsentPdf'),
+	);
+
+	const mockSignatureImage = urlJoin(CONSENT_UI_URL, '/assets/images/placeholder-signature.png');
+
+	return (
+		<TempPdfButtons
+			currentLang={currentLang}
+			studyConsentPdfUrl={studyConsentPdfUrl}
+			mockSignatureImage={mockSignatureImage}
+		/>
+	);
+};
+
+export default TempPdfButtonsWrapper;

--- a/apps/consent-ui/src/components/views/Dashboard/generateConsentPdf/mockData.ts
+++ b/apps/consent-ui/src/components/views/Dashboard/generateConsentPdf/mockData.ts
@@ -17,15 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import urlJoin from 'url-join';
-
-import { getAppConfig } from 'src/config';
-
 import { GenerateConsentPdfParams } from './types';
-
-const { CONSENT_UI_URL } = getAppConfig();
-
-const mockSignatureImage = urlJoin(CONSENT_UI_URL, '/assets/images/placeholder-signature.png');
 
 // properties starting with mock = unknown property name/type/schema
 
@@ -34,7 +26,7 @@ export const mockDataGuardian: GenerateConsentPdfParams = {
 	currentLifecycleState: 'CONSENTED',
 	guardianName: 'Marge Simpson',
 	mockDate: new Date(),
-	mockSignatureImage,
+	mockSignatureImage: '',
 	participantOhipFirstName: 'Lisa',
 	participantOhipLastName: 'Simpson',
 	RECONTACT__FUTURE_RESEARCH: false,
@@ -49,7 +41,7 @@ export const mockDataParticipant: GenerateConsentPdfParams = {
 	currentLifecycleState: 'CONSENTED',
 	guardianName: undefined,
 	mockDate: new Date(),
-	mockSignatureImage,
+	mockSignatureImage: '',
 	participantOhipFirstName: 'Homer',
 	participantOhipLastName: 'Simpson',
 	RECONTACT__FUTURE_RESEARCH: true,
@@ -64,7 +56,7 @@ export const mockDataSubstitute: GenerateConsentPdfParams = {
 	currentLifecycleState: 'CONSENTED',
 	guardianName: 'Homer Simpson',
 	mockDate: new Date(),
-	mockSignatureImage,
+	mockSignatureImage: '',
 	participantOhipFirstName: 'Abraham',
 	participantOhipLastName: 'Simpson',
 	RECONTACT__FUTURE_RESEARCH: false,

--- a/apps/consent-ui/src/components/views/Dashboard/index.tsx
+++ b/apps/consent-ui/src/components/views/Dashboard/index.tsx
@@ -19,7 +19,6 @@
 
 import clsx from 'clsx';
 import Image from 'next/image';
-import urlJoin from 'url-join';
 
 import Card from 'src/components/common/Card';
 import { getTranslation, ValidLanguage } from 'src/i18n';
@@ -27,12 +26,11 @@ import ConsentsImage from 'src/../public/assets/images/consents.jpeg';
 import PaddedContainer from 'src/components/common/PaddedContainer';
 import LocalizedLink from 'src/components/common/Link/LocalizedLink';
 import { getAppConfig } from 'src/config';
-import { ASSETS_PATH, CONSENT_PDFS_PATH } from 'src/constants';
 import { getNotificationTranslations } from 'src/components/providers/NotificationProvider/getNotificationTranslations';
 
 import styles from './Dashboard.module.scss';
 import DashboardNotification from './notifications/DashboardNotification';
-import TempPdfButtons from './TempPdfButtons';
+import TempPdfButtonsWrapper from './TempPdfButtonsWrapper';
 
 // TODO remove after backend hookup
 const statuses = ['disabled', 'incomplete', 'complete'] as const;
@@ -41,12 +39,6 @@ const consentStatus = statuses[2];
 const DashboardComponent = async ({ currentLang }: { currentLang: ValidLanguage }) => {
 	const { translate } = getTranslation(currentLang);
 	const notificationTranslations = getNotificationTranslations(currentLang);
-
-	const studyConsentPdfUrl = urlJoin(
-		ASSETS_PATH,
-		CONSENT_PDFS_PATH,
-		translate('assetUrls', 'studyConsentPdf'),
-	);
 
 	const { FEATURE_CONSENT_PDF_BUTTONS } = getAppConfig();
 
@@ -63,9 +55,7 @@ const DashboardComponent = async ({ currentLang }: { currentLang: ValidLanguage 
 				<div className={styles.content}>
 					<h2>{translate('dashboard', 'reviewOhcrnConsents')}</h2>
 					<p>{translate('dashboard', 'reviewConsentsDescription')}</p>
-					{FEATURE_CONSENT_PDF_BUTTONS && (
-						<TempPdfButtons currentLang={currentLang} studyConsentPdfUrl={studyConsentPdfUrl} />
-					)}
+					{FEATURE_CONSENT_PDF_BUTTONS && <TempPdfButtonsWrapper currentLang={currentLang} />}
 					<div className={styles['button-container']}>
 						{consentStatus == 'complete' ? (
 							<LocalizedLink

--- a/apps/consent-ui/src/config/appConfig.ts
+++ b/apps/consent-ui/src/config/appConfig.ts
@@ -17,41 +17,14 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-export type AppConfig = {
-	AUTH_DISABLED: boolean;
-	CONSENT_API_URL: string;
-	CONSENT_UI_URL: string;
-	FEATURE_CONSENT_PDF_BUTTONS?: boolean;
-	OHCRN_EMAIL?: string;
-	OHCRN_HOME_LINK?: string;
-	RECAPTCHA_SITE_KEY?: string;
-	KEYCLOAK_ISSUER: string;
-	KEYCLOAK_CLIENT_ID: string;
-	TOKEN_ENCRYPTION_KEY: string;
-	TOKEN_MAX_AGE: number;
-	VERBOSE_AXIOS_LOGGING: boolean;
-};
+import 'server-only';
 
-export const defaultAppConfig: AppConfig = {
-	AUTH_DISABLED: false,
-	CONSENT_API_URL: 'http://localhost:8080',
-	CONSENT_UI_URL: 'http://localhost:3000',
-	FEATURE_CONSENT_PDF_BUTTONS: false,
-	OHCRN_EMAIL: '',
-	OHCRN_HOME_LINK: '',
-	RECAPTCHA_SITE_KEY: undefined,
-	KEYCLOAK_ISSUER: '', // TODO: should set this up to error on server start, if not provided
-	KEYCLOAK_CLIENT_ID: '', // TODO:  should set this up to error on server start, if not provided
-	TOKEN_ENCRYPTION_KEY: '',
-	TOKEN_MAX_AGE: 3600,
-	VERBOSE_AXIOS_LOGGING: false,
-};
+import { defaultAppConfig, AppConfig } from 'src/config/types';
 
 /**
  * Returns environment variables for server components
  * @returns {AppConfig}
  */
-// TODO: enforce server-only usage. To be completed as a follow-up to https://github.com/OHCRN/platform/issues/422
 const getAppConfig = (): AppConfig => ({
 	AUTH_DISABLED: process.env.AUTH_DISABLED === 'true' || defaultAppConfig.AUTH_DISABLED,
 	CONSENT_API_URL: process.env.CONSENT_API_URL || defaultAppConfig.CONSENT_API_URL,

--- a/apps/consent-ui/src/config/clientConfig.ts
+++ b/apps/consent-ui/src/config/clientConfig.ts
@@ -17,30 +17,9 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { defaultAppConfig } from 'src/config';
+import 'server-only';
 
-/**
- * Environment variables exposed to client components via AppConfigContext
- *
- * Note: this config is exposed to the client, so it should not contain any sensitive information
- */
-export type ClientAppConfig = {
-	CONSENT_API_URL: string;
-	CONSENT_UI_URL: string;
-	FEATURE_CONSENT_PDF_BUTTONS?: boolean;
-	OHCRN_EMAIL?: string;
-	OHCRN_HOME_LINK?: string;
-	RECAPTCHA_SITE_KEY?: string;
-};
-
-export const defaultClientAppConfig: ClientAppConfig = {
-	CONSENT_API_URL: defaultAppConfig.CONSENT_API_URL,
-	CONSENT_UI_URL: defaultAppConfig.CONSENT_UI_URL,
-	FEATURE_CONSENT_PDF_BUTTONS: defaultAppConfig.FEATURE_CONSENT_PDF_BUTTONS,
-	OHCRN_EMAIL: defaultAppConfig.OHCRN_EMAIL,
-	OHCRN_HOME_LINK: defaultAppConfig.OHCRN_HOME_LINK,
-	RECAPTCHA_SITE_KEY: defaultAppConfig.RECAPTCHA_SITE_KEY,
-};
+import { defaultAppConfig, ClientAppConfig } from 'src/config/types';
 
 /**
  * Returns environment variables for client components
@@ -48,7 +27,6 @@ export const defaultClientAppConfig: ClientAppConfig = {
  * Note: intended for **SERVER COMPONENTS ONLY**. Access these values from the client using the `useAppConfigContext` hook.
  * @returns {ClientAppConfig}
  */
-// TODO: enforce server-only usage. To be completed as a follow-up to https://github.com/OHCRN/platform/issues/422
 const getClientAppConfig = (): ClientAppConfig => ({
 	CONSENT_API_URL: process.env.CONSENT_API_URL || defaultAppConfig.CONSENT_API_URL,
 	CONSENT_UI_URL: process.env.CONSENT_UI_URL || defaultAppConfig.CONSENT_UI_URL,

--- a/apps/consent-ui/src/config/types.ts
+++ b/apps/consent-ui/src/config/types.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * All environment variables for server components
+ */
+export type AppConfig = {
+	AUTH_DISABLED: boolean;
+	CONSENT_API_URL: string;
+	CONSENT_UI_URL: string;
+	FEATURE_CONSENT_PDF_BUTTONS?: boolean;
+	OHCRN_EMAIL?: string;
+	OHCRN_HOME_LINK?: string;
+	RECAPTCHA_SITE_KEY?: string;
+	KEYCLOAK_ISSUER: string;
+	KEYCLOAK_CLIENT_ID: string;
+	TOKEN_ENCRYPTION_KEY: string;
+	TOKEN_MAX_AGE: number;
+	VERBOSE_AXIOS_LOGGING: boolean;
+};
+
+export const defaultAppConfig: AppConfig = {
+	AUTH_DISABLED: false,
+	CONSENT_API_URL: 'http://localhost:8080',
+	CONSENT_UI_URL: 'http://localhost:3000',
+	FEATURE_CONSENT_PDF_BUTTONS: false,
+	OHCRN_EMAIL: '',
+	OHCRN_HOME_LINK: '',
+	RECAPTCHA_SITE_KEY: undefined,
+	KEYCLOAK_ISSUER: '', // TODO: should set this up to error on server start, if not provided
+	KEYCLOAK_CLIENT_ID: '', // TODO:  should set this up to error on server start, if not provided
+	TOKEN_ENCRYPTION_KEY: '',
+	TOKEN_MAX_AGE: 3600,
+	VERBOSE_AXIOS_LOGGING: false,
+};
+
+/**
+ * Environment variables exposed to client components via AppConfigContext
+ *
+ * Note: this config is exposed to the client, so it should not contain any secrets
+ */
+export type ClientAppConfig = {
+	CONSENT_API_URL: string;
+	CONSENT_UI_URL: string;
+	FEATURE_CONSENT_PDF_BUTTONS?: boolean;
+	OHCRN_EMAIL?: string;
+	OHCRN_HOME_LINK?: string;
+	RECAPTCHA_SITE_KEY?: string;
+};
+
+export const defaultClientAppConfig: ClientAppConfig = {
+	CONSENT_API_URL: defaultAppConfig.CONSENT_API_URL,
+	CONSENT_UI_URL: defaultAppConfig.CONSENT_UI_URL,
+	FEATURE_CONSENT_PDF_BUTTONS: defaultAppConfig.FEATURE_CONSENT_PDF_BUTTONS,
+	OHCRN_EMAIL: defaultAppConfig.OHCRN_EMAIL,
+	OHCRN_HOME_LINK: defaultAppConfig.OHCRN_HOME_LINK,
+	RECAPTCHA_SITE_KEY: defaultAppConfig.RECAPTCHA_SITE_KEY,
+};


### PR DESCRIPTION
## Description of Changes

### Consent UI
Enforces server-only usage of app config functions. Also contains a small refactor of the temporary PDF buttons preventing the app config function from getting called client-side.
* Refactors `appConfig.ts` and `clientConfig.ts` to support `server-only` usage, splitting type definitions out into separate `types.ts` in `src/config/`
* Adds import for `server-only` package on `appConfig.ts` and `clientConfig.ts`
* Adds an intermediate `TempPDFButtonsWrapper` server component to fetch env vars
* Removes temporary PDF button logic from `Dashboard` and into `TempPDFButtonsWrapper` for easy disposal later 🙏

## PR Readiness Checklist

- [ ] "Expected Outcome(s)" in ticket have been met
- [ ] Ticket number included in PR title
- [ ] Connected ticket to PR
- [x] Labels added to PR for service name (`consent-api`, `data-mapper`, etc...), type (`chore`, `documentation`, etc...), status (`draft`, `on-hold`, etc...) **if applicable**
- [x] Manual testing completed
- [x] Builds locally without errors or warnings
- [ ] Tests are updated (if required) and passing
- [ ] PR feedback has been addressed **if applicable**
- [ ] New environment variables added to `.env.schema` files, `README.md`
- [x] Added copyrights to new files
