### PR TITLE
♻️ 476 - create Register base type

### DIFF
--- a/packages/types/src/entities/Register.ts
+++ b/packages/types/src/entities/Register.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { z } from 'zod';
+
+import { createDateOfBirthRequestSchema } from '../common/index.js';
+
+import { ParticipantNameFields } from './Participant.js';
+import { EmptyOrOptionalName, EmptyOrOptionalPhoneNumber } from './fields/index.js';
+
+export const isGuardianField = z.object({
+	isGuardian: z.boolean(),
+});
+
+// STEP 1
+
+export const RegisterRequestParticipantNameFields = ParticipantNameFields.and(
+	z.object({
+		participantPreferredName: EmptyOrOptionalName,
+	}),
+);
+
+// participant phone number - required for participants, not allowed for guardians
+export const RegisterRequestParticipantPhoneNumberField = isGuardianField.and(
+	z.object({
+		participantPhoneNumber: EmptyOrOptionalPhoneNumber,
+	}),
+);
+export type RegisterRequestParticipantPhoneNumberField = z.infer<
+	typeof RegisterRequestParticipantPhoneNumberField
+>;
+
+export const DateOfBirthField = createDateOfBirthRequestSchema();
+
+// guardian fields - required for guardians, not allowed for participants
+export const RegisterRequestGuardianFields = isGuardianField.and(
+	z.object({
+		guardianName: EmptyOrOptionalName,
+		guardianPhoneNumber: EmptyOrOptionalPhoneNumber,
+		guardianRelationship: EmptyOrOptionalName,
+	}),
+);
+export type RegisterRequestGuardianFields = z.infer<typeof RegisterRequestGuardianFields>;
+
+// STEP 2
+
+export const RegisterRequestEmailAddressFields = isGuardianField.and(
+	z.object({
+		guardianEmailAddress: z.string().email().optional(),
+		participantEmailAddress: z.string().email().optional(),
+	}),
+);
+export type RegisterRequestEmailAddressFields = z.infer<typeof RegisterRequestEmailAddressFields>;

--- a/packages/types/src/entities/index.ts
+++ b/packages/types/src/entities/index.ts
@@ -30,5 +30,6 @@ export * from './InformedConsent.js';
 export * from './Participant.js';
 export * from './ParticipantIdentification.js';
 export * from './ParticipantResponse.js';
+export * from './Register.js';
 export * from './User.js';
 export * from './fields/index.js';

--- a/packages/types/src/services/consentUi/requests/Register.ts
+++ b/packages/types/src/services/consentUi/requests/Register.ts
@@ -19,56 +19,27 @@
 
 import { z } from 'zod';
 
-import { ConsentToBeContacted, ParticipantNameFields } from '../../../entities/Participant.js';
-import { NonEmptyString, createDateOfBirthRequestSchema } from '../../../common/index.js';
+import { NonEmptyString } from '../../../common/index.js';
 import {
-	EmptyOrOptionalName,
-	EmptyOrOptionalPhoneNumber,
+	ConsentToBeContacted,
+	DateOfBirthField,
+	RegisterRequestEmailAddressFields,
+	RegisterRequestGuardianFields,
+	RegisterRequestParticipantNameFields,
+	RegisterRequestParticipantPhoneNumberField,
 	hasMatchingPasswords,
-} from '../../../entities/fields/index.js';
+} from '../../../entities/index.js';
 import {
-	hasRequiredRegistrationPhoneNumberForGuardianStatus,
-	hasRequiredRegistrationEmailForGuardianStatus,
 	hasRequiredGuardianInfoForRegistration,
+	hasRequiredRegistrationEmailForGuardianStatus,
+	hasRequiredRegistrationPhoneNumberForGuardianStatus,
 } from '../utils/index.js';
 
-const isGuardianField = z.object({
-	isGuardian: z.boolean(),
-});
-
-// STEP 1
-
-export const RegisterRequestParticipantNameFields = ParticipantNameFields.and(
-	z.object({
-		participantPreferredName: EmptyOrOptionalName,
-	}),
-);
-
-// participant phone number - required for participants, not allowed for guardians
-const RegisterRequestParticipantPhoneNumberField = isGuardianField.and(
-	z.object({
-		participantPhoneNumber: EmptyOrOptionalPhoneNumber,
-	}),
-);
-export type RegisterRequestParticipantPhoneNumberField = z.infer<
-	typeof RegisterRequestParticipantPhoneNumberField
->;
 export const RegisterRequestParticipantPhoneNumberFieldRefined =
 	RegisterRequestParticipantPhoneNumberField.superRefine(
 		hasRequiredRegistrationPhoneNumberForGuardianStatus,
 	);
 
-const DateOfBirthField = createDateOfBirthRequestSchema();
-
-// guardian fields - required for guardians, not allowed for participants
-const RegisterRequestGuardianFields = isGuardianField.and(
-	z.object({
-		guardianName: EmptyOrOptionalName,
-		guardianPhoneNumber: EmptyOrOptionalPhoneNumber,
-		guardianRelationship: EmptyOrOptionalName,
-	}),
-);
-export type RegisterRequestGuardianFields = z.infer<typeof RegisterRequestGuardianFields>;
 export const RegisterRequestGuardianFieldsRefined = RegisterRequestGuardianFields.superRefine(
 	hasRequiredGuardianInfoForRegistration,
 );
@@ -80,15 +51,6 @@ export const RegisterFormStep1 = RegisterRequestParticipantNameFields.and(
 	.and(DateOfBirthField);
 export type RegisterFormStep1 = z.infer<typeof RegisterFormStep1>;
 
-// STEP 2
-
-const RegisterRequestEmailAddressFields = isGuardianField.and(
-	z.object({
-		guardianEmailAddress: z.string().email().optional(),
-		participantEmailAddress: z.string().email().optional(),
-	}),
-);
-export type RegisterRequestEmailAddressFields = z.infer<typeof RegisterRequestEmailAddressFields>;
 const RegisterEmailAddressFieldsRefined = RegisterRequestEmailAddressFields.superRefine(
 	hasRequiredRegistrationEmailForGuardianStatus,
 );

--- a/packages/types/src/services/consentUi/utils/guardianFields.ts
+++ b/packages/types/src/services/consentUi/utils/guardianFields.ts
@@ -23,8 +23,9 @@ import {
 	RegisterRequestParticipantPhoneNumberField,
 	RegisterRequestEmailAddressFields,
 	RegisterRequestGuardianFields,
-} from '../requests/Register.js';
+} from '../../../entities/index.js';
 import { hasValue, isEmptyOrUndefined } from '../../../common/index.js';
+
 import { addZodCustomError } from './index.js';
 
 /**

--- a/packages/types/tests/services/participantRegistrationRefinements.spec.ts
+++ b/packages/types/tests/services/participantRegistrationRefinements.spec.ts
@@ -22,12 +22,12 @@ import { describe, expect, it } from 'vitest';
 import {
 	RegisterFormStep2,
 	RegisterRequestGuardianFieldsRefined,
-	RegisterRequestParticipantNameFields,
 	RegisterRequestParticipantPhoneNumberFieldRefined,
 } from '../../src/services/consentUi/requests/Register.js';
 import { createDateOfBirthRequestSchema } from '../../src/common/utils/dateOfBirth.js';
 import { setupDateOfBirthTest } from '../utils/dateOfBirth.spec.js';
 import { formatZodFieldErrorsForTesting } from '../utils/zodUtils.js';
+import { RegisterRequestParticipantNameFields } from '../../src/entities/index.js';
 
 describe('ParticipantRegistrationRequest', () => {
 	const {


### PR DESCRIPTION
## Description of Changes

Creates a Register base type file for the consentUi Register request schema to import from, to fix some circular imports.

## PR Readiness Checklist

- [ ] "Expected Outcome(s)" in ticket have been met
- [ ] Ticket number included in PR title
- [ ] Connected ticket to PR
- [ ] Labels added to PR for service name (`consent-api`, `data-mapper`, etc...), type (`chore`, `documentation`, etc...), status (`draft`, `on-hold`, etc...) **if applicable**
- [ ] Manual testing completed
- [ ] Builds locally without errors or warnings
- [ ] Tests are updated (if required) and passing
- [ ] PR feedback has been addressed **if applicable**
- [ ] New environment variables added to `.env.schema` files, `README.md`
- [ ] Added copyrights to new files
